### PR TITLE
Cleanup, API command tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ Import variables from a tfvars file or the process environment into the current 
 | 3    | Authentication Error             | `tfcloud auth login`        |
 | 4    | Network error                    | Check connectivity          |
 | 5    | API Server Error Persists        | Try again later             |
+| 130  | Canceled (ctrl-c).               | &mdash;                     |

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/cli v1.1.7
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-tfe v1.78.1-0.20260414223040-554d4064682a
+	github.com/hashicorp/go-tfe v1.78.1-0.20260420185033-6d0ba63f80ef
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/lithammer/dedent v1.1.0
@@ -26,6 +26,7 @@ require (
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	golang.org/x/net v0.50.0
 	golang.org/x/term v0.40.0
+	golang.org/x/text v0.34.0
 )
 
 require (
@@ -88,7 +89,6 @@ require (
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-tfe v1.78.1-0.20260414223040-554d4064682a h1:K5t3L7CDC3gtbLI28Zwlb8DwBn0+ojUEKVBmzZhQ0ck=
-github.com/hashicorp/go-tfe v1.78.1-0.20260414223040-554d4064682a/go.mod h1:NCc9n8HN05g6Bu5v0a3JhkOoWN42DF/Jk0nDQSaZwFI=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-tfe v1.78.1-0.20260420185033-6d0ba63f80ef h1:0CyteoDGeCWpYDuLfwwb4+dVzOusuzoN1Kv+z5mGJrE=
+github.com/hashicorp/go-tfe v1.78.1-0.20260420185033-6d0ba63f80ef/go.mod h1:NCc9n8HN05g6Bu5v0a3JhkOoWN42DF/Jk0nDQSaZwFI=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -27,12 +27,15 @@ import (
 )
 
 const (
-	MaxPaginateRecords = 1000
+	// MaxPaginateRecords is the maximum number of records that will be returned
+	// when using the --paginate argument, regardless of how many records are available.
+	MaxPaginateRecords = 2000
 )
 
 // Opts stores the options parsed from flags for the API command.
 type Opts struct {
 	IO           iostreams.IOStreams
+	Output       *format.Outputter
 	ShutdownCtx  context.Context
 	Client       *client.Client
 	Quiet        bool
@@ -53,6 +56,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 	opts := &Opts{
 		IO:          ctx.IO,
 		ShutdownCtx: ctx.ShutdownCtx,
+		Output:      ctx.Output,
 	}
 
 	cmd := &cmd.Command{
@@ -102,7 +106,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 				},
 				{
 					Name:          "paginate",
-					Description:   "Automatically paginate through results and stream them, one resource at a time. Only applies to successful responses with JSON:API document bodies.",
+					Description:   fmt.Sprintf("Automatically paginate through results and stream them, one resource at a time, up to %d records. Only applies to successful responses with JSON:API document bodies.", MaxPaginateRecords),
 					Value:         flagvalue.Simple(false, &opts.Paginate),
 					IsBooleanFlag: true,
 				},
@@ -206,11 +210,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 func runAPI(opts *Opts) error {
 	// Handle -f query fields
 	query := opts.URL.Query()
-	for _, item := range opts.Query {
-		key, value, err := splitPair(item, '=')
-		if err != nil {
-			return err
-		}
+	for key, value := range opts.Query {
 		query.Set(key, value)
 	}
 	opts.URL.RawQuery = query.Encode()
@@ -282,8 +282,7 @@ func runAPI(opts *Opts) error {
 		return err
 	}
 
-	output := format.New(opts.IO)
-	return output.Display(disp)
+	return opts.Output.Display(disp)
 }
 
 func inferMethod(explicit string, hasAttributes, hasInput bool) string {

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -24,34 +24,21 @@ import (
 	"github.com/hashicorp/tfcloud/internal/pkg/format"
 	"github.com/hashicorp/tfcloud/internal/pkg/heredoc"
 	"github.com/hashicorp/tfcloud/internal/pkg/iostreams"
-	"github.com/hashicorp/tfcloud/internal/pkg/profile"
 )
 
-type apiRequester interface {
-	Base() *url.URL
-	RawRequest(context.Context, *client.Request) (*client.Response, error)
-}
-
-type realAPIClient struct {
-	client *client.Client
-}
-
-func (c *realAPIClient) Base() *url.URL {
-	return c.client.BaseURL
-}
-
-func (c *realAPIClient) RawRequest(ctx context.Context, req *client.Request) (*client.Response, error) {
-	return c.client.RawRequest(ctx, req)
-}
+const (
+	MaxPaginateRecords = 1000
+)
 
 // Opts stores the options parsed from flags for the API command.
 type Opts struct {
 	IO           iostreams.IOStreams
-	Output       *format.Outputter
+	ShutdownCtx  context.Context
 	Client       *client.Client
-	Profile      *profile.Profile
+	Quiet        bool
+	Debug        bool
 	Headers      []string
-	url          *url.URL
+	URL          *url.URL
 	Attributes   map[string]string
 	Query        map[string]string
 	PathTokens   map[string]string
@@ -64,9 +51,8 @@ type Opts struct {
 // NewCmdAPI creates the `tfcloud api` command.
 func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 	opts := &Opts{
-		IO:      ctx.IO,
-		Output:  ctx.Output,
-		Profile: ctx.Profile,
+		IO:          ctx.IO,
+		ShutdownCtx: ctx.ShutdownCtx,
 	}
 
 	cmd := &cmd.Command{
@@ -186,21 +172,29 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 			},
 		},
 		RunF: func(_ *cmd.Command, args []string) error {
-			// TODO: replace `return err` statements with something that can be shown to the user.
 			if len(args) < 1 {
 				return cmd.ErrDisplayUsage
 			}
 
 			path := args[0]
 
-			resolvedURL, err := client.ResolveURL(ctx.APIClient.BaseURL, path)
+			apiClient, err := ctx.NewAPIClient()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create API client: %w", err)
 			}
-			opts.url = resolvedURL
-			opts.Client = ctx.APIClient
 
-			return runAPI(ctx.ShutdownCtx, opts)
+			resolvedURL, err := client.ResolveURL(*apiClient.BaseURL, path)
+			if err != nil {
+				return fmt.Errorf("invalid input path/URL %q", path)
+			}
+
+			opts.URL = resolvedURL
+			opts.Client = apiClient
+
+			opts.Debug = ctx.Profile.GetVerbosity() == "debug" || ctx.Profile.GetVerbosity() == "trace"
+			opts.Quiet = ctx.Profile.IsQuiet()
+
+			return runAPI(opts)
 		},
 	}
 
@@ -209,8 +203,9 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 	return cmd
 }
 
-func runAPI(ctx context.Context, opts *Opts) error {
-	query := opts.url.Query()
+func runAPI(opts *Opts) error {
+	// Handle -f query fields
+	query := opts.URL.Query()
 	for _, item := range opts.Query {
 		key, value, err := splitPair(item, '=')
 		if err != nil {
@@ -218,9 +213,10 @@ func runAPI(ctx context.Context, opts *Opts) error {
 		}
 		query.Set(key, value)
 	}
-	opts.url.RawQuery = query.Encode()
+	opts.URL.RawQuery = query.Encode()
 
-	body, contentType, err := buildRequestBody(opts.url.Path, opts.InputRequest, opts.Attributes, opts.ResourceType, opts.IO.In())
+	// Construct a request
+	body, contentType, err := buildRequestBody(opts.URL.Path, opts.InputRequest, opts.Attributes, opts.ResourceType, opts.IO.In())
 	if err != nil {
 		return err
 	}
@@ -237,9 +233,10 @@ func runAPI(ctx context.Context, opts *Opts) error {
 		requestHeaders.Set("Accept", "application/vnd.api+json")
 	}
 
-	response, err := opts.Client.RawRequest(ctx, &client.Request{
+	// Make the request
+	response, err := opts.Client.RawRequest(opts.ShutdownCtx, &client.Request{
 		Method:  method,
-		URL:     opts.url,
+		URL:     opts.URL,
 		Headers: requestHeaders,
 		Body:    body,
 	})
@@ -248,13 +245,13 @@ func runAPI(ctx context.Context, opts *Opts) error {
 	}
 
 	verbose := false
-	if opts.Profile.GetVerbosity() == "debug" || opts.Profile.GetVerbosity() == "trace" {
-		logRequestResponse(opts.IO.Err(), method, opts.url, requestHeaders, response)
+	if opts.Debug {
+		logRequestResponse(opts.IO.Err(), method, opts.URL, requestHeaders, response)
 		verbose = true
 	}
 
 	if opts.Paginate && response.StatusCode >= 200 && response.StatusCode < 300 {
-		response, err = paginateResponse(ctx, &realAPIClient{client: opts.Client}, response, requestHeaders, verbose, opts.IO.Err())
+		response, err = paginateResponse(opts.ShutdownCtx, opts.Client, response, requestHeaders, verbose, opts.IO.Err())
 		if err != nil {
 			return err
 		}
@@ -275,7 +272,7 @@ func runAPI(ctx context.Context, opts *Opts) error {
 		return errors.New(response.Status)
 	}
 
-	if opts.Profile.IsQuiet() || len(bytes.TrimSpace(response.Body)) == 0 {
+	if opts.Quiet || len(bytes.TrimSpace(response.Body)) == 0 {
 		return nil
 	}
 
@@ -285,7 +282,8 @@ func runAPI(ctx context.Context, opts *Opts) error {
 		return err
 	}
 
-	return opts.Output.Display(disp)
+	output := format.New(opts.IO)
+	return output.Display(disp)
 }
 
 func inferMethod(explicit string, hasAttributes, hasInput bool) string {
@@ -406,13 +404,13 @@ func splitPair(item string, sep rune) (string, string, error) {
 	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
 }
 
-func paginateResponse(ctx context.Context, apiClient apiRequester, initial *client.Response, headers http.Header, verbose bool, stderr io.Writer) (*client.Response, error) {
+func paginateResponse(ctx context.Context, apiClient *client.Client, initial *client.Response, headers http.Header, verbose bool, stderr io.Writer) (*client.Response, error) {
 	combined, nextURL, err := parsePaginationPayload(initial.Body)
 	if err != nil || nextURL == nil {
 		return initial, err
 	}
 
-	for len(combined) < 1000 && nextURL != nil {
+	for len(combined) < MaxPaginateRecords && nextURL != nil {
 		resp, reqErr := apiClient.RawRequest(ctx, &client.Request{
 			Method:  http.MethodGet,
 			URL:     nextURL,
@@ -434,8 +432,8 @@ func paginateResponse(ctx context.Context, apiClient apiRequester, initial *clie
 		}
 		combined = append(combined, pageData...)
 		nextURL = pageNext
-		if len(combined) > 1000 {
-			combined = combined[:1000]
+		if len(combined) > MaxPaginateRecords {
+			combined = combined[:MaxPaginateRecords]
 		}
 		initial = resp
 	}

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -1,0 +1,602 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/go-tfe"
+
+	"github.com/hashicorp/tfcloud/internal/pkg/client"
+	"github.com/hashicorp/tfcloud/internal/pkg/format"
+	"github.com/hashicorp/tfcloud/internal/pkg/iostreams"
+)
+
+func TestRunAPI_DefaultGet(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":   "ws-1",
+						"type": "workspaces",
+						"attributes": map[string]any{
+							"name": "alpha",
+						},
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, "GET", recorder.Last().Method)
+	require.Equal(t, "/api/v2/workspaces", recorder.Last().Path)
+	require.Equal(t, "application/vnd.api+json", recorder.Last().Headers.Get("Accept"))
+	require.Contains(t, io.Output.String(), "alpha")
+	require.Empty(t, io.Error.String())
+}
+
+func TestRunAPI_AttributesInferPostAndResourceType(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"POST /api/v2/projects": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{
+					"id":   "prj-1",
+					"type": "projects",
+					"attributes": map[string]any{
+						"name": "demo",
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/projects")
+		opts.Attributes = map[string]string{
+			"name": "demo",
+		}
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, "POST", recorder.Last().Method)
+	require.Equal(t, "application/vnd.api+json", recorder.Last().Headers.Get("Content-Type"))
+	assertJSONBodyEqual(t, map[string]any{
+		"data": map[string]any{
+			"type": "projects",
+			"attributes": map[string]any{
+				"name": "demo",
+			},
+		},
+	}, recorder.Last().JSONBody(t))
+	require.Contains(t, io.Output.String(), "Name:")
+	require.Contains(t, io.Output.String(), "demo")
+}
+
+func TestRunAPI_AttributesInferResourceTypeFromMemberPath(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"POST /api/v2/workspaces/ws-123/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{
+					"id":   "var-1",
+					"type": "vars",
+					"attributes": map[string]any{
+						"key": "region",
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-123/vars")
+		opts.Attributes = map[string]string{"key": "region"}
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "vars", nestedMap(t, recorder.Last().JSONBody(t), "data")["type"])
+}
+
+func TestRunAPI_ExplicitTypeOverridesInferredType(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"POST /api/v2/workspaces/ws-123/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{
+					"id":         "custom-1",
+					"type":       "custom-vars",
+					"attributes": map[string]any{"key": "region"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-123/vars")
+		opts.Attributes = map[string]string{"key": "region"}
+		opts.ResourceType = "custom-vars"
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "custom-vars", nestedMap(t, recorder.Last().JSONBody(t), "data")["type"])
+}
+
+func TestRunAPI_InputInlineInferPost(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"POST /api/v2/runs": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{
+					"id":         "run-1",
+					"type":       "runs",
+					"attributes": map[string]any{"message": "queued"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	input := `{"data":{"type":"runs","attributes":{"message":"queued"}}}`
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/runs")
+		opts.InputRequest = input
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, "POST", recorder.Last().Method)
+	require.Equal(t, "application/vnd.api+json", recorder.Last().Headers.Get("Content-Type"))
+	assertJSONBodyEqual(t, jsonMap(t, input), recorder.Last().JSONBody(t))
+	require.Contains(t, io.Output.String(), "queued")
+}
+
+func TestRunAPI_InputFromStdin(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"POST /api/v2/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{
+					"id":         "var-1",
+					"type":       "vars",
+					"attributes": map[string]any{"key": "AWS_REGION"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	io.Input.WriteString(`{"data":{"type":"vars","attributes":{"key":"AWS_REGION"}}}`)
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/vars")
+		opts.InputRequest = "-"
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "AWS_REGION", nestedMap(t, nestedMap(t, recorder.Last().JSONBody(t), "data"), "attributes")["key"])
+}
+
+func TestRunAPI_ExplicitMethodHeadersAndQuery(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"PATCH /api/v2/workspaces/ws-1": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": map[string]any{
+					"id":         "ws-1",
+					"type":       "workspaces",
+					"attributes": map[string]any{"name": "beta"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-1")
+		opts.Method = http.MethodPatch
+		opts.Query = map[string]string{"include": "organization", "page[number]": "2"}
+		opts.Headers = []string{"X-Test: yes", "Accept: application/custom+json"}
+		opts.InputRequest = `{"data":{"type":"workspaces","attributes":{"name":"beta"}}}`
+	}))
+	require.NoError(t, err)
+
+	req := recorder.Last()
+	require.Equal(t, "PATCH", req.Method)
+	require.Equal(t, "yes", req.Headers.Get("X-Test"))
+	require.Equal(t, "application/custom+json", req.Headers.Get("Accept"))
+	require.Equal(t, "organization", req.Query.Get("include"))
+	require.Equal(t, "2", req.Query.Get("page[number]"))
+}
+
+func TestRunAPI_Paginate(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{"id": "ws-1", "type": "workspaces", "attributes": map[string]any{"name": "alpha"}},
+				},
+				"links": map[string]any{"next": serverURL(r) + "/api/v2/workspaces?page[number]=2"},
+				"meta":  map[string]any{"pagination": map[string]any{"total-count": 1}},
+			})
+		},
+		"GET /api/v2/workspaces?page[number]=2": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{"id": "ws-2", "type": "workspaces", "attributes": map[string]any{"name": "beta"}},
+				},
+				"links": map[string]any{"next": nil},
+				"meta":  map[string]any{"pagination": map[string]any{"total-count": 2}},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+		opts.Paginate = true
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, recorder.All(), 2)
+	require.Contains(t, io.Output.String(), "alpha")
+	require.Contains(t, io.Output.String(), "beta")
+}
+
+func TestRunAPI_DebugLogsRequestAndResponse(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{map[string]any{"id": "ws-1", "type": "workspaces", "attributes": map[string]any{"name": "alpha"}}},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+		opts.Debug = true
+		opts.Headers = []string{"X-Debug: yes"}
+	}))
+	require.NoError(t, err)
+
+	require.Contains(t, io.Error.String(), "> GET ")
+	require.Contains(t, io.Error.String(), "X-Debug: yes")
+	require.Contains(t, io.Error.String(), "< 200 OK")
+}
+
+func TestRunAPI_QuietSuppressesOutput(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{map[string]any{"id": "ws-1", "type": "workspaces", "attributes": map[string]any{"name": "alpha"}}},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+		opts.Quiet = true
+	}))
+	require.NoError(t, err)
+	require.Empty(t, io.Output.String())
+}
+
+func TestRunAPI_EmptyBodyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"DELETE /api/v2/workspaces/ws-1": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-1")
+		opts.Method = http.MethodDelete
+	}))
+	require.NoError(t, err)
+	require.Empty(t, io.Output.String())
+}
+
+func TestRunAPI_ErrorResponseSummarizesJSONAPIErrors(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusUnprocessableEntity, map[string]any{
+				"errors": []any{
+					map[string]any{"title": "Validation failed", "detail": "name is required"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+	}))
+	assert.ErrorIs(t, err, tfe.ErrUnprocessableEntity)
+	var apiErr *tfe.APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Len(t, apiErr.Details, 1)
+	require.Equal(t, apiErr.Details[0], "Validation failed: name is required")
+}
+
+func TestRunAPI_ErrorResponseFallsBackToRawBody(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, "bad request !!!")
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+	}))
+	assert.ErrorIs(t, err, tfe.ErrBadRequest)
+	var apiErr *tfe.APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Len(t, apiErr.Details, 0)
+	require.Equal(t, apiErr.Error(), "400 Bad Request")
+}
+
+func TestRunAPI_ErrorResponseHTML(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = io.WriteString(w, "<html>Not found</html>")
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+	}))
+	require.EqualError(t, err, "an HTML response was received, likely an error page")
+}
+
+func TestRunAPI_PaginateReturnsErrorResponseFromLaterPage(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data":  []any{map[string]any{"id": "ws-1", "type": "workspaces", "attributes": map[string]any{"name": "alpha"}}},
+				"links": map[string]any{"next": serverURL(r) + "/api/v2/workspaces?page[number]=2"},
+			})
+		},
+		"GET /api/v2/workspaces?page[number]=2": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusTooManyRequests, map[string]any{
+				"errors": []any{map[string]any{"title": "Rate limit", "detail": "slow down"}},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+		opts.Paginate = true
+	}))
+	assert.ErrorIs(t, err, tfe.ErrTooManyRequests)
+	var apiErr *tfe.APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Len(t, apiErr.Details, 1)
+	require.Equal(t, apiErr.Details[0], "Rate limit: slow down")
+}
+
+func TestRunAPI_InvalidHeaderReturnsError(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, "https://example.test", io, func(opts *Opts) {
+		opts.URL = mustParseURL(t, "https://example.test/api/v2/workspaces")
+		opts.Headers = []string{"invalid-header"}
+	}))
+	require.EqualError(t, err, `invalid pair "invalid-header"`)
+}
+
+type recordedRequest struct {
+	Method  string
+	Path    string
+	Query   url.Values
+	Headers http.Header
+	Body    []byte
+}
+
+func (r recordedRequest) JSONBody(t *testing.T) map[string]any {
+	t.Helper()
+	if len(r.Body) == 0 {
+		return nil
+	}
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(r.Body, &body))
+	return body
+}
+
+type requestRecorder struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+func (r *requestRecorder) Record(req recordedRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req)
+}
+
+func (r *requestRecorder) Last() recordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.requests[len(r.requests)-1]
+}
+
+func (r *requestRecorder) All() []recordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	requests := make([]recordedRequest, len(r.requests))
+	copy(requests, r.requests)
+	return requests
+}
+
+func newAPITestServer(routes map[string]http.HandlerFunc) (*httptest.Server, *requestRecorder) {
+	recorder := &requestRecorder{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		recorder.Record(recordedRequest{
+			Method:  r.Method,
+			Path:    r.URL.Path,
+			Query:   r.URL.Query(),
+			Headers: r.Header.Clone(),
+			Body:    body,
+		})
+
+		if h, ok := routes[routeKey(r)]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[fmt.Sprintf("%s %s", r.Method, r.URL.Path)]; ok {
+			h(w, r)
+			return
+		}
+
+		http.Error(w, "unexpected request "+routeKey(r), http.StatusInternalServerError)
+	})
+	return httptest.NewServer(handler), recorder
+}
+
+func routeKey(r *http.Request) string {
+	if r.URL.RawQuery == "" {
+		return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+	}
+	return fmt.Sprintf("%s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+}
+
+func newTestOpts(t *testing.T, address string, io *iostreams.Testing, mutate func(*Opts)) *Opts {
+	t.Helper()
+	apiClient, err := client.New(address, "test-token", http.Header{
+		"User-Agent": []string{"tfcloud-cli/test"},
+	})
+	require.NoError(t, err)
+
+	opts := &Opts{
+		IO:          io,
+		Output:      format.New(io),
+		ShutdownCtx: context.Background(),
+		Client:      apiClient,
+		Headers:     []string{},
+		Attributes:  map[string]string{},
+		Query:       map[string]string{},
+		PathTokens:  map[string]string{},
+	}
+	mutate(opts)
+	return opts
+}
+
+func mustResolveTestURL(t *testing.T, base, path string) *url.URL {
+	t.Helper()
+	baseURL := mustParseURL(t, base)
+	resolved, err := client.ResolveURL(*baseURL, path)
+	require.NoError(t, err)
+	return resolved
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func assertJSONBodyEqual(t *testing.T, want, got map[string]any) {
+	t.Helper()
+	wantJSON, err := json.Marshal(want)
+	require.NoError(t, err)
+	gotJSON, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.JSONEq(t, string(wantJSON), string(gotJSON))
+}
+
+func jsonMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &payload))
+	return payload
+}
+
+func nestedMap(t *testing.T, payload map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := payload[key].(map[string]any)
+	require.True(t, ok, "expected map at key %q, got %T", key, payload[key])
+	return value
+}
+
+func writeJSONAPIResponse(w http.ResponseWriter, status int, payload map[string]any) {
+	w.Header().Set("Content-Type", "application/vnd.api+json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func serverURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
+}

--- a/internal/commands/variable/variable_import.go
+++ b/internal/commands/variable/variable_import.go
@@ -150,12 +150,17 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 				return errors.New("could not resolve target workspace; set --organization and --workspace or run inside a repository with terraform cloud configuration") // this should be impossible to hit due to the previous block, but we'll check again before API calls just in case
 			}
 
-			target, err := resolveTarget(ctx.ShutdownCtx, ctx.APIClient, opts)
+			apiClient, err := ctx.NewAPIClient()
+			if err != nil {
+				return fmt.Errorf("unable to create API client: %w", err)
+			}
+
+			target, err := resolveTarget(ctx.ShutdownCtx, apiClient, opts)
 			if err != nil {
 				return err
 			}
 
-			existing, err := listExistingVariables(ctx.ShutdownCtx, ctx.APIClient, target)
+			existing, err := listExistingVariables(ctx.ShutdownCtx, apiClient, target)
 			if err != nil {
 				return err
 			}
@@ -176,13 +181,13 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 			for _, variable := range imported {
 				key := existingKey(variable.Key, variable.Category)
 				if current, ok := existing[key]; ok {
-					if err := updateVariable(ctx.ShutdownCtx, ctx.APIClient, target, current.ID, variable); err != nil {
+					if err := updateVariable(ctx.ShutdownCtx, apiClient, target, current.ID, variable); err != nil {
 						return err
 					}
 					updated++
 					continue
 				}
-				if err := createVariable(ctx.ShutdownCtx, ctx.APIClient, target, variable); err != nil {
+				if err := createVariable(ctx.ShutdownCtx, apiClient, target, variable); err != nil {
 					return err
 				}
 				created++
@@ -239,7 +244,7 @@ func resolveTarget(ctx context.Context, apiClient *client.Client, opts *ImportOp
 }
 
 func resolveWorkspace(ctx context.Context, apiClient *client.Client, opts *ImportOpts) (string, error) {
-	endpoint, err := client.ResolveURL(apiClient.BaseURL, fmt.Sprintf("/organizations/%s/workspaces/%s", url.PathEscape(opts.Organization), url.PathEscape(opts.Workspace)))
+	endpoint, err := client.ResolveURL(*apiClient.BaseURL, fmt.Sprintf("/organizations/%s/workspaces/%s", url.PathEscape(opts.Organization), url.PathEscape(opts.Workspace)))
 	if err != nil {
 		return "", err
 	}
@@ -265,7 +270,7 @@ func resolveWorkspace(ctx context.Context, apiClient *client.Client, opts *Impor
 }
 
 func resolveVariableSet(ctx context.Context, apiClient *client.Client, opts *ImportOpts) (string, error) {
-	endpoint, err := client.ResolveURL(apiClient.BaseURL, fmt.Sprintf("/organizations/%s/varsets", url.PathEscape(opts.Organization)))
+	endpoint, err := client.ResolveURL(*apiClient.BaseURL, fmt.Sprintf("/organizations/%s/varsets", url.PathEscape(opts.Organization)))
 	if err != nil {
 		return "", err
 	}
@@ -332,7 +337,7 @@ func resolveVariableSet(ctx context.Context, apiClient *client.Client, opts *Imp
 }
 
 func listExistingVariables(ctx context.Context, apiClient *client.Client, target *variableTarget) (map[string]existingVariable, error) {
-	endpoint, err := client.ResolveURL(apiClient.BaseURL, target.Path)
+	endpoint, err := client.ResolveURL(*apiClient.BaseURL, target.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +368,7 @@ func listExistingVariables(ctx context.Context, apiClient *client.Client, target
 }
 
 func createVariable(ctx context.Context, apiClient *client.Client, target *variableTarget, variable terraformcfg.ImportedVariable) error {
-	endpoint, err := client.ResolveURL(apiClient.BaseURL, target.Path)
+	endpoint, err := client.ResolveURL(*apiClient.BaseURL, target.Path)
 	if err != nil {
 		return err
 	}
@@ -382,7 +387,7 @@ func createVariable(ctx context.Context, apiClient *client.Client, target *varia
 }
 
 func updateVariable(ctx context.Context, apiClient *client.Client, target *variableTarget, variableID string, variable terraformcfg.ImportedVariable) error {
-	endpoint, err := client.ResolveURL(apiClient.BaseURL, fmt.Sprintf(target.ItemPath, url.PathEscape(variableID)))
+	endpoint, err := client.ResolveURL(*apiClient.BaseURL, fmt.Sprintf(target.ItemPath, url.PathEscape(variableID)))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -57,7 +57,7 @@ type Response struct {
 	Body []byte
 }
 
-// New constructs a configured API client from CLI configuration.
+// New constructs a configured API client from CLI configuration profile.
 func New(p *profile.Profile, defaultHeaders http.Header) (*Client, error) {
 	tfeClient, err := tfe.NewClient(&tfe.Config{
 		Address: fmt.Sprintf("https://%s", p.Hostname),
@@ -134,7 +134,7 @@ func (c *Client) RawRequest(ctx context.Context, req *Request) (*Response, error
 }
 
 // ResolveURL resolves an absolute or base-relative API path against base.
-func ResolveURL(base *url.URL, path string) (*url.URL, error) {
+func ResolveURL(base url.URL, path string) (*url.URL, error) {
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
 		return url.Parse(path)
 	}
@@ -143,10 +143,11 @@ func ResolveURL(base *url.URL, path string) (*url.URL, error) {
 		path = "/" + path
 	}
 
-	resolved := *base
+	resolved := base
 	resolved.Path = strings.TrimRight(base.Path, "/") + path
 	resolved.RawQuery = ""
 	resolved.Fragment = ""
+
 	return &resolved, nil
 }
 

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -7,6 +7,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,8 +16,6 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	abs "github.com/microsoft/kiota-abstractions-go"
-
-	"github.com/hashicorp/tfcloud/internal/pkg/profile"
 )
 
 // Client wraps the configured HCP Terraform API clients and request helpers.
@@ -24,9 +23,7 @@ type Client struct {
 	// TFE is the underlying go-tfe client.
 	TFE *tfe.Client
 	// HTTP is the shared HTTP client used for raw requests.
-	HTTP *http.Client
-	// Adapter is the Kiota request adapter from the go-tfe client.
-	Adapter abs.RequestAdapter
+	Adapter *tfe.TFERequestAdapter
 	// BaseURL is the resolved API base URL.
 	BaseURL *url.URL
 	// DefaultHeaders are applied to every request.
@@ -57,11 +54,11 @@ type Response struct {
 	Body []byte
 }
 
-// New constructs a configured API client from CLI configuration profile.
-func New(p *profile.Profile, defaultHeaders http.Header) (*Client, error) {
+// New constructs a configured API client from an API address and token.
+func New(address, token string, defaultHeaders http.Header) (*Client, error) {
 	tfeClient, err := tfe.NewClient(&tfe.Config{
-		Address: fmt.Sprintf("https://%s", p.Hostname),
-		Token:   p.Token,
+		Address: address,
+		Token:   token,
 		Headers: defaultHeaders,
 	})
 	if err != nil {
@@ -77,8 +74,7 @@ func New(p *profile.Profile, defaultHeaders http.Header) (*Client, error) {
 	baseURL := tfeClient.BaseURL()
 	return &Client{
 		TFE:            tfeClient,
-		HTTP:           native.Client,
-		Adapter:        adapter,
+		Adapter:        native,
 		BaseURL:        &baseURL,
 		DefaultHeaders: defaultHeaders,
 	}, nil
@@ -114,8 +110,12 @@ func (c *Client) RawRequest(ctx context.Context, req *Request) (*Response, error
 		return nil, fmt.Errorf("unexpected native request type %T", nativeRequest)
 	}
 
-	httpResp, err := c.HTTP.Do(httpReq)
+	httpResp, err := c.Adapter.Client.Do(httpReq)
 	if err != nil {
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			return nil, urlErr.Err
+		}
 		return nil, err
 	}
 	defer httpResp.Body.Close()

--- a/internal/pkg/cmd/command_internal.go
+++ b/internal/pkg/cmd/command_internal.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -57,6 +58,9 @@ func (c *Command) errorToExitCode(args []string, err error) int {
 		}
 	} else if errors.As(err, &exitCodeErr) {
 		exitCode = exitCodeErr.Code
+	} else if errors.Is(err, context.Canceled) {
+		fmt.Fprintf(io.Err(), "%s Operation canceled", cs.FailureIcon())
+		return 130
 	}
 
 	fmt.Fprintf(io.Err(), "%s %s\n", cs.ErrorLabel(), wordWrap(err.Error(), 120))
@@ -67,7 +71,7 @@ func (c *Command) errorToExitCode(args []string, err error) int {
 func (c *Command) Run(args []string) int {
 	// Get the colorscheme
 	io := c.getIO()
-	cs := c.getIO().ColorScheme()
+	cs := io.ColorScheme()
 
 	if c.RunF == nil {
 		if len(c.children) != 0 {

--- a/internal/pkg/cmd/command_internal.go
+++ b/internal/pkg/cmd/command_internal.go
@@ -56,6 +56,14 @@ func (c *Command) errorToExitCode(args []string, err error) int {
 			fmt.Fprintf(io.Err(), "%s Server error: %s\n", cs.ErrorLabel(), apiErr)
 			return 5
 		}
+		fmt.Fprint(io.Err(), heredoc.New(io, heredoc.WithPreserveNewlines(), heredoc.WithWidth(0)).Mustf(`
+%s Request error: %s.
+
+{{ Bold "Error Details" }}
+  - %s
+
+`, cs.ErrorLabel(), apiErr.Message, strings.Join(apiErr.Details, "\n  - ")))
+		return 1
 	} else if errors.As(err, &exitCodeErr) {
 		exitCode = exitCodeErr.Code
 	} else if errors.Is(err, context.Canceled) {

--- a/internal/pkg/cmd/context.go
+++ b/internal/pkg/cmd/context.go
@@ -240,7 +240,7 @@ func (ctx *Context) applyGlobalFlags(c *Command) error {
 
 // NewAPIClient returns a new API Client configured using the context Profile.
 func (ctx *Context) NewAPIClient() (*client.Client, error) {
-	apiClient, err := client.New(ctx.Profile, http.Header{
+	apiClient, err := client.New(fmt.Sprintf("https://%s", ctx.Profile.Hostname), ctx.Profile.Token, http.Header{
 		"User-Agent": []string{fmt.Sprintf("tfcloud-cli/%s", config.Version)},
 	})
 	if err != nil {

--- a/internal/pkg/cmd/context.go
+++ b/internal/pkg/cmd/context.go
@@ -40,8 +40,6 @@ type Context struct {
 	flags GlobalFlags
 
 	Profile *profile.Profile
-
-	APIClient *client.Client
 }
 
 // GlobalFlags contains the global flags.
@@ -163,23 +161,8 @@ func ConfigureRootCommand(ctx *Context, cmd *Command) {
 			return err
 		}
 
-		client, err := ctx.newAPIClient()
-		if err != nil && !c.NoAuthRequired {
-			return err
-		}
-		ctx.APIClient = client
 		return nil
 	}
-}
-
-func (ctx *Context) newAPIClient() (*client.Client, error) {
-	apiClient, err := client.New(ctx.Profile, http.Header{
-		"User-Agent": []string{fmt.Sprintf("tfcloud-cli/%s", config.Version)},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return apiClient, nil
 }
 
 // applyGlobalFlags applies the global flags.
@@ -253,6 +236,17 @@ func (ctx *Context) applyGlobalFlags(c *Command) error {
 	}
 
 	return nil
+}
+
+// NewAPIClient returns a new API Client configured using the context Profile.
+func (ctx *Context) NewAPIClient() (*client.Client, error) {
+	apiClient, err := client.New(ctx.Profile, http.Header{
+		"User-Agent": []string{fmt.Sprintf("tfcloud-cli/%s", config.Version)},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return apiClient, nil
 }
 
 // ParseFlags can be used to parse the flags for a given command before it is


### PR DESCRIPTION
Fixes some problems with the api command that I noticed and adds a lot of tests for that command. Improves 4XX response error rendering

<img width="919" height="583" alt="Screenshot 2026-04-20 at 11 39 59" src="https://github.com/user-attachments/assets/43c36926-c73f-4a22-8660-dc4d7c34cd7a" />


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
