### PR TITLE
Refactor and test `variable import`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/cli v1.1.7
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-tfe v1.78.1-0.20260420185033-6d0ba63f80ef
+	github.com/hashicorp/go-tfe v1.78.1-0.20260423131248-88fe79ca7400
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/lithammer/dedent v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/cli v1.1.7
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-tfe v1.78.1-0.20260423131248-88fe79ca7400
+	github.com/hashicorp/go-tfe v1.78.1-0.20260423211818-e37f9ff614bd
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/lithammer/dedent v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-tfe v1.78.1-0.20260420185033-6d0ba63f80ef h1:0CyteoDGeCWpYDuLfwwb4+dVzOusuzoN1Kv+z5mGJrE=
-github.com/hashicorp/go-tfe v1.78.1-0.20260420185033-6d0ba63f80ef/go.mod h1:NCc9n8HN05g6Bu5v0a3JhkOoWN42DF/Jk0nDQSaZwFI=
+github.com/hashicorp/go-tfe v1.78.1-0.20260423131248-88fe79ca7400 h1:QYrijpaehLQ6JtPAQm0lCt/r+KbL2pIlBcRehYMc3nQ=
+github.com/hashicorp/go-tfe v1.78.1-0.20260423131248-88fe79ca7400/go.mod h1:NCc9n8HN05g6Bu5v0a3JhkOoWN42DF/Jk0nDQSaZwFI=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-tfe v1.78.1-0.20260423131248-88fe79ca7400 h1:QYrijpaehLQ6JtPAQm0lCt/r+KbL2pIlBcRehYMc3nQ=
-github.com/hashicorp/go-tfe v1.78.1-0.20260423131248-88fe79ca7400/go.mod h1:NCc9n8HN05g6Bu5v0a3JhkOoWN42DF/Jk0nDQSaZwFI=
+github.com/hashicorp/go-tfe v1.78.1-0.20260423211818-e37f9ff614bd h1:hsSXxFs5tzC9sl8ZXv8X4KDiKuJIPa5FFj2w3klNKMM=
+github.com/hashicorp/go-tfe v1.78.1-0.20260423211818-e37f9ff614bd/go.mod h1:NCc9n8HN05g6Bu5v0a3JhkOoWN42DF/Jk0nDQSaZwFI=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/internal/commands/variable/target.go
+++ b/internal/commands/variable/target.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-tfe/api"
+
 	"github.com/hashicorp/tfcloud/internal/pkg/client"
 	terraformcfg "github.com/hashicorp/tfcloud/internal/pkg/terraform"
 )

--- a/internal/commands/variable/target.go
+++ b/internal/commands/variable/target.go
@@ -90,9 +90,9 @@ func (t *variableTarget) createVariable(ctx context.Context, variable terraformc
 	var err error
 	switch t.Kind {
 	case kindVariableSet:
-		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().Post(ctx, client.NewVarsetsVarsPostBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().Post(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	case kindWorkspace:
-		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().Post(ctx, client.NewWorkspacesVarsPostBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().Post(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	default:
 		return fmt.Errorf("unknown variable target kind %s, this is a bug in tfcloud", t.Kind)
 	}
@@ -104,9 +104,9 @@ func (t *variableTarget) updateVariable(ctx context.Context, variableID string, 
 	var err error
 	switch t.Kind {
 	case kindVariableSet:
-		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().ById(variableID).Patch(ctx, client.NewVarsetsVarsPatchBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().ById(variableID).Patch(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	case kindWorkspace:
-		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().ById(variableID).Patch(ctx, client.NewWorkspacesVarsPatchBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().ById(variableID).Patch(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	default:
 		return fmt.Errorf("unknown variable target kind %s, this is a bug in tfcloud", t.Kind)
 	}

--- a/internal/commands/variable/target.go
+++ b/internal/commands/variable/target.go
@@ -1,0 +1,114 @@
+package variable
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe/api"
+	"github.com/hashicorp/tfcloud/internal/pkg/client"
+	terraformcfg "github.com/hashicorp/tfcloud/internal/pkg/terraform"
+)
+
+type variableTargetKind string
+
+type variableTarget struct {
+	apiClient *api.ApiClient
+	Kind      variableTargetKind
+	ID        string
+	Name      string
+}
+
+type existingVariable struct {
+	ID       string
+	Key      string
+	Category string
+}
+
+var (
+	kindWorkspace   variableTargetKind = "workspace"
+	kindVariableSet variableTargetKind = "variable set"
+)
+
+func newVariableSetVariableTarget(apiClient *client.Client, id, name string) *variableTarget {
+	return &variableTarget{
+		apiClient: apiClient.TFE.API,
+		Kind:      kindVariableSet,
+		ID:        id,
+		Name:      name,
+	}
+}
+
+func newWorkspaceVariableTarget(apiClient *client.Client, id, name string) *variableTarget {
+	return &variableTarget{
+		apiClient: apiClient.TFE.API,
+		Kind:      kindWorkspace,
+		ID:        id,
+		Name:      name,
+	}
+}
+
+func (t *variableTarget) String() string {
+	return fmt.Sprintf("%s %q", t.Kind, t.Name)
+}
+
+func (t *variableTarget) listExistingVariables(ctx context.Context) (existingVariables, error) {
+	existing := make(existingVariables)
+	switch t.Kind {
+	case kindWorkspace:
+		vars, err := t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().Get(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range vars.GetData() {
+			existing.Add(existingVariable{
+				ID:       *item.GetId(),
+				Key:      *item.GetAttributes().GetKey(),
+				Category: item.GetAttributes().GetCategory().String(),
+			})
+		}
+	case kindVariableSet:
+		vars, err := t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().Get(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range vars.GetData() {
+			existing.Add(existingVariable{
+				ID:       *item.GetId(),
+				Key:      *item.GetAttributes().GetKey(),
+				Category: item.GetAttributes().GetCategory().String(),
+			})
+		}
+	}
+
+	return existing, nil
+}
+
+func (t *variableTarget) createVariable(ctx context.Context, variable terraformcfg.ImportedVariable) error {
+	var err error
+	switch t.Kind {
+	case kindVariableSet:
+		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().Post(ctx, client.NewVarsetsVarsPostBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+	case kindWorkspace:
+		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().Post(ctx, client.NewWorkspacesVarsPostBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+	default:
+		return fmt.Errorf("unknown variable target kind %s, this is a bug in tfcloud", t.Kind)
+	}
+
+	return err
+}
+
+func (t *variableTarget) updateVariable(ctx context.Context, variableID string, variable terraformcfg.ImportedVariable) error {
+	var err error
+	switch t.Kind {
+	case kindVariableSet:
+		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().ById(variableID).Patch(ctx, client.NewVarsetsVarsPatchBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+	case kindWorkspace:
+		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().ById(variableID).Patch(ctx, client.NewWorkspacesVarsPatchBody(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+	default:
+		return fmt.Errorf("unknown variable target kind %s, this is a bug in tfcloud", t.Kind)
+	}
+
+	return err
+}

--- a/internal/commands/variable/variable_import.go
+++ b/internal/commands/variable/variable_import.go
@@ -21,6 +21,7 @@ import (
 // ImportOpts stores the options parsed from flags for the variable import command.
 type ImportOpts struct {
 	IO                 iostreams.IOStreams
+	ShutdownCtx        context.Context
 	TFVarsFileToImport string
 	Client             *client.Client
 	Env                []string
@@ -44,7 +45,8 @@ func (e existingVariables) Get(category, key string) (existingVariable, bool) {
 // NewCmdVariableImport creates the `tfcloud variable import` command.
 func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 	opts := &ImportOpts{
-		IO: ctx.IO,
+		IO:          ctx.IO,
+		ShutdownCtx: ctx.ShutdownCtx,
 	}
 
 	cmd := &cmd.Command{
@@ -145,14 +147,14 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 
 			opts.Client = apiClient
 
-			return runVariableImport(ctx.ShutdownCtx, opts)
+			return runVariableImport(opts)
 		},
 	}
 
 	return cmd
 }
 
-func runVariableImport(ctx context.Context, opts *ImportOpts) error {
+func runVariableImport(opts *ImportOpts) error {
 	var imported []terraformcfg.ImportedVariable
 	if opts.TFVarsFileToImport != "" {
 		vars, err := terraformcfg.ParseTFVarsFile(opts.TFVarsFileToImport)
@@ -180,12 +182,12 @@ func runVariableImport(ctx context.Context, opts *ImportOpts) error {
 		return cmd.ErrDisplayUsage
 	}
 
-	target, err := resolveTarget(ctx, opts)
+	target, err := resolveTarget(opts.ShutdownCtx, opts)
 	if err != nil {
 		return err
 	}
 
-	existing, err := target.listExistingVariables(ctx)
+	existing, err := target.listExistingVariables(opts.ShutdownCtx)
 	if err != nil {
 		return err
 	}
@@ -205,13 +207,13 @@ func runVariableImport(ctx context.Context, opts *ImportOpts) error {
 	updated := 0
 	for _, variable := range imported {
 		if current, ok := existing.Get(variable.Category, variable.Key); ok {
-			if err := target.updateVariable(ctx, current.ID, variable); err != nil {
+			if err := target.updateVariable(opts.ShutdownCtx, current.ID, variable); err != nil {
 				return err
 			}
 			updated++
 			continue
 		}
-		if err := target.createVariable(ctx, variable); err != nil {
+		if err := target.createVariable(opts.ShutdownCtx, variable); err != nil {
 			return err
 		}
 		created++

--- a/internal/commands/variable/variable_import.go
+++ b/internal/commands/variable/variable_import.go
@@ -20,12 +20,14 @@ import (
 
 // ImportOpts stores the options parsed from flags for the variable import command.
 type ImportOpts struct {
-	IO              iostreams.IOStreams
-	Env             []string
-	VariableSetName string
-	Organization    string
-	Workspace       string
-	Overwrite       bool
+	IO                 iostreams.IOStreams
+	TFVarsFileToImport string
+	Client             *client.Client
+	Env                []string
+	VariableSetName    string
+	Organization       string
+	Workspace          string
+	Overwrite          bool
 }
 
 type existingVariables map[string]existingVariable
@@ -105,34 +107,12 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 			},
 		},
 		RunF: func(_ *cmd.Command, args []string) error {
-			var imported []terraformcfg.ImportedVariable
 			if len(args) > 1 {
 				return cmd.ErrDisplayUsage
 			}
 
 			if len(args) == 1 {
-				vars, err := terraformcfg.ParseTFVarsFile(args[0])
-				if err != nil {
-					return fmt.Errorf("failed parsing tfvars file: %w", err)
-				}
-				imported = append(imported, vars...)
-			}
-
-			for _, name := range opts.Env {
-				value, ok := os.LookupEnv(name)
-				if !ok {
-					return fmt.Errorf("environment variable %q is not set", name)
-				}
-				imported = append(imported, terraformcfg.ImportedVariable{
-					Key:       name,
-					Value:     value,
-					Category:  "env",
-					HCL:       false,
-					Sensitive: true,
-				})
-			}
-			if len(imported) == 0 {
-				return cmd.ErrDisplayUsage
+				opts.TFVarsFileToImport = args[0]
 			}
 
 			if opts.Organization == "" {
@@ -163,65 +143,98 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 				return fmt.Errorf("unable to create API client: %w", err)
 			}
 
-			target, err := resolveTarget(ctx.ShutdownCtx, apiClient, opts)
-			if err != nil {
-				return err
-			}
+			opts.Client = apiClient
 
-			existing, err := target.listExistingVariables(ctx.ShutdownCtx)
-			if err != nil {
-				return err
-			}
-
-			duplicates := make([]string, 0)
-			for _, variable := range imported {
-				if _, ok := existing.Get(variable.Category, variable.Key); ok && !opts.Overwrite {
-					duplicates = append(duplicates, fmt.Sprintf("%s (%s)", variable.Key, variable.Category))
-				}
-			}
-
-			if len(duplicates) > 0 {
-				return fmt.Errorf("variables already exist; rerun with --overwrite to update: %s", strings.Join(duplicates, ", "))
-			}
-
-			created := 0
-			updated := 0
-			for _, variable := range imported {
-				if current, ok := existing.Get(variable.Category, variable.Key); ok {
-					if err := target.updateVariable(ctx.ShutdownCtx, current.ID, variable); err != nil {
-						return err
-					}
-					updated++
-					continue
-				}
-				if err := target.createVariable(ctx.ShutdownCtx, variable); err != nil {
-					return err
-				}
-				created++
-			}
-
-			fmt.Fprintf(ctx.IO.Err(), "%s imported %d variables into %s (%d created, %d updated)", opts.IO.ColorScheme().SuccessIcon(), len(imported), target.String(), created, updated)
-			return nil
+			return runVariableImport(ctx.ShutdownCtx, opts)
 		},
 	}
 
 	return cmd
 }
 
-func resolveTarget(ctx context.Context, apiClient *client.Client, opts *ImportOpts) (*variableTarget, error) {
-	resolver := client.NewResolver(apiClient, opts.VariableSetName != "", false)
+func runVariableImport(ctx context.Context, opts *ImportOpts) error {
+	var imported []terraformcfg.ImportedVariable
+	if opts.TFVarsFileToImport != "" {
+		vars, err := terraformcfg.ParseTFVarsFile(opts.TFVarsFileToImport)
+		if err != nil {
+			return fmt.Errorf("failed parsing tfvars file: %w", err)
+		}
+		imported = append(imported, vars...)
+	}
+
+	for _, name := range opts.Env {
+		value, ok := os.LookupEnv(name)
+		if !ok {
+			return fmt.Errorf("environment variable %q is not set", name)
+		}
+		imported = append(imported, terraformcfg.ImportedVariable{
+			Key:       name,
+			Value:     value,
+			Category:  "env",
+			HCL:       false,
+			Sensitive: true,
+		})
+	}
+
+	if len(imported) == 0 {
+		return cmd.ErrDisplayUsage
+	}
+
+	target, err := resolveTarget(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	existing, err := target.listExistingVariables(ctx)
+	if err != nil {
+		return err
+	}
+
+	duplicates := make([]string, 0)
+	for _, variable := range imported {
+		if _, ok := existing.Get(variable.Category, variable.Key); ok && !opts.Overwrite {
+			duplicates = append(duplicates, fmt.Sprintf("%s (%s)", variable.Key, variable.Category))
+		}
+	}
+
+	if len(duplicates) > 0 {
+		return fmt.Errorf("variables already exist; rerun with --overwrite to update: %s", strings.Join(duplicates, ", "))
+	}
+
+	created := 0
+	updated := 0
+	for _, variable := range imported {
+		if current, ok := existing.Get(variable.Category, variable.Key); ok {
+			if err := target.updateVariable(ctx, current.ID, variable); err != nil {
+				return err
+			}
+			updated++
+			continue
+		}
+		if err := target.createVariable(ctx, variable); err != nil {
+			return err
+		}
+		created++
+	}
+
+	fmt.Fprintf(opts.IO.Err(), "%s imported %d variables into %s (%d created, %d updated)", opts.IO.ColorScheme().SuccessIcon(), len(imported), target.String(), created, updated)
+	return nil
+}
+
+func resolveTarget(ctx context.Context, opts *ImportOpts) (*variableTarget, error) {
+	resolver := client.NewResolver(opts.Client, opts.VariableSetName != "", false)
 
 	if opts.VariableSetName != "" {
 		result, err := resolver.VariableSet(ctx, opts.Organization, opts.VariableSetName)
 		if err != nil {
 			return nil, err
 		}
-		return newVariableSetVariableTarget(apiClient, *result, opts.VariableSetName), nil
+		return newVariableSetVariableTarget(opts.Client, *result, opts.VariableSetName), nil
 	}
 
-	workspace, err := apiClient.TFE.API.Organizations().ByOrganization_name(opts.Organization).Workspaces().ByWorkspace_name(opts.Workspace).Get(ctx, nil)
+	workspace, err := opts.Client.TFE.API.Organizations().ByOrganization_name(opts.Organization).Workspaces().ByWorkspace_name(opts.Workspace).Get(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
-	return newWorkspaceVariableTarget(apiClient, *workspace.GetData().GetId(), opts.Workspace), nil
+	return newWorkspaceVariableTarget(opts.Client, *workspace.GetData().GetId(), opts.Workspace), nil
 }

--- a/internal/commands/variable/variable_import.go
+++ b/internal/commands/variable/variable_import.go
@@ -5,11 +5,8 @@ package variable
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -29,6 +26,17 @@ type ImportOpts struct {
 	Organization    string
 	Workspace       string
 	Overwrite       bool
+}
+
+type existingVariables map[string]existingVariable
+
+func (e existingVariables) Add(v existingVariable) {
+	e[v.Category+"\x00"+v.Key] = v
+}
+
+func (e existingVariables) Get(category, key string) (existingVariable, bool) {
+	result, ok := e[category+"\x00"+key]
+	return result, ok
 }
 
 // NewCmdVariableImport creates the `tfcloud variable import` command.
@@ -160,18 +168,18 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 				return err
 			}
 
-			existing, err := listExistingVariables(ctx.ShutdownCtx, apiClient, target)
+			existing, err := target.listExistingVariables(ctx.ShutdownCtx)
 			if err != nil {
 				return err
 			}
 
 			duplicates := make([]string, 0)
 			for _, variable := range imported {
-				key := existingKey(variable.Key, variable.Category)
-				if _, ok := existing[key]; ok && !opts.Overwrite {
+				if _, ok := existing.Get(variable.Category, variable.Key); ok && !opts.Overwrite {
 					duplicates = append(duplicates, fmt.Sprintf("%s (%s)", variable.Key, variable.Category))
 				}
 			}
+
 			if len(duplicates) > 0 {
 				return fmt.Errorf("variables already exist; rerun with --overwrite to update: %s", strings.Join(duplicates, ", "))
 			}
@@ -179,21 +187,20 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 			created := 0
 			updated := 0
 			for _, variable := range imported {
-				key := existingKey(variable.Key, variable.Category)
-				if current, ok := existing[key]; ok {
-					if err := updateVariable(ctx.ShutdownCtx, apiClient, target, current.ID, variable); err != nil {
+				if current, ok := existing.Get(variable.Category, variable.Key); ok {
+					if err := target.updateVariable(ctx.ShutdownCtx, current.ID, variable); err != nil {
 						return err
 					}
 					updated++
 					continue
 				}
-				if err := createVariable(ctx.ShutdownCtx, apiClient, target, variable); err != nil {
+				if err := target.createVariable(ctx.ShutdownCtx, variable); err != nil {
 					return err
 				}
 				created++
 			}
 
-			fmt.Fprintf(ctx.IO.Err(), "%s imported %d variables into %s (%d created, %d updated)", opts.IO.ColorScheme().SuccessIcon(), len(imported), target.DisplayName, created, updated)
+			fmt.Fprintf(ctx.IO.Err(), "%s imported %d variables into %s (%d created, %d updated)", opts.IO.ColorScheme().SuccessIcon(), len(imported), target.String(), created, updated)
 			return nil
 		},
 	}
@@ -201,232 +208,20 @@ func NewCmdVariableImport(ctx *cmd.Context) *cmd.Command {
 	return cmd
 }
 
-type variableTarget struct {
-	Kind        string
-	ID          string
-	DisplayName string
-	Path        string
-	ItemPath    string
-}
-
-type existingVariable struct {
-	ID       string
-	Key      string
-	Category string
-}
-
 func resolveTarget(ctx context.Context, apiClient *client.Client, opts *ImportOpts) (*variableTarget, error) {
+	resolver := client.NewResolver(apiClient, opts.VariableSetName != "", false)
+
 	if opts.VariableSetName != "" {
-		id, err := resolveVariableSet(ctx, apiClient, opts)
+		result, err := resolver.VariableSet(ctx, opts.Organization, opts.VariableSetName)
 		if err != nil {
 			return nil, err
 		}
-		return &variableTarget{
-			Kind:        "variable set",
-			ID:          id,
-			DisplayName: fmt.Sprintf("variable set %q", opts.VariableSetName),
-			Path:        fmt.Sprintf("/varsets/%s/relationships/vars", url.PathEscape(id)),
-			ItemPath:    fmt.Sprintf("/varsets/%s/relationships/vars/%%s", url.PathEscape(id)),
-		}, nil
+		return newVariableSetVariableTarget(apiClient, *result, opts.VariableSetName), nil
 	}
 
-	workspaceID, err := resolveWorkspace(ctx, apiClient, opts)
+	workspace, err := apiClient.TFE.API.Organizations().ByOrganization_name(opts.Organization).Workspaces().ByWorkspace_name(opts.Workspace).Get(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &variableTarget{
-		Kind:        "workspace",
-		ID:          workspaceID,
-		DisplayName: fmt.Sprintf("workspace %q", opts.Workspace),
-		Path:        fmt.Sprintf("/workspaces/%s/vars", url.PathEscape(workspaceID)),
-		ItemPath:    fmt.Sprintf("/workspaces/%s/vars/%%s", url.PathEscape(workspaceID)),
-	}, nil
-}
-
-func resolveWorkspace(ctx context.Context, apiClient *client.Client, opts *ImportOpts) (string, error) {
-	endpoint, err := client.ResolveURL(*apiClient.BaseURL, fmt.Sprintf("/organizations/%s/workspaces/%s", url.PathEscape(opts.Organization), url.PathEscape(opts.Workspace)))
-	if err != nil {
-		return "", err
-	}
-	resp, err := apiClient.RawRequest(ctx, &client.Request{Method: http.MethodGet, URL: endpoint, Headers: jsonAPIHeaders()})
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("%s: %s", resp.Status, client.SummarizeAPIErrors(resp.Body))
-	}
-	var payload struct {
-		Data struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
-		return "", err
-	}
-	if payload.Data.ID == "" {
-		return "", fmt.Errorf("workspace %q returned no id", opts.Workspace)
-	}
-	return payload.Data.ID, nil
-}
-
-func resolveVariableSet(ctx context.Context, apiClient *client.Client, opts *ImportOpts) (string, error) {
-	endpoint, err := client.ResolveURL(*apiClient.BaseURL, fmt.Sprintf("/organizations/%s/varsets", url.PathEscape(opts.Organization)))
-	if err != nil {
-		return "", err
-	}
-	query := endpoint.Query()
-	query.Set("q", opts.VariableSetName)
-	endpoint.RawQuery = query.Encode()
-
-	resp, err := apiClient.RawRequest(ctx, &client.Request{Method: http.MethodGet, URL: endpoint, Headers: jsonAPIHeaders()})
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("%s: %s", resp.Status, client.SummarizeAPIErrors(resp.Body))
-	}
-
-	var payload struct {
-		Data []struct {
-			ID         string `json:"id"`
-			Attributes struct {
-				Name string `json:"name"`
-			} `json:"attributes"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
-		return "", err
-	}
-	for _, item := range payload.Data {
-		if item.Attributes.Name == opts.VariableSetName {
-			return item.ID, nil
-		}
-	}
-
-	body := map[string]any{
-		"data": map[string]any{
-			"type": "varsets",
-			"attributes": map[string]any{
-				"name": opts.VariableSetName,
-			},
-		},
-	}
-	encoded, err := json.Marshal(body)
-	if err != nil {
-		return "", err
-	}
-	createResp, err := apiClient.RawRequest(ctx, &client.Request{Method: http.MethodPost, URL: endpoint, Headers: jsonAPIHeaders(), Body: encoded})
-	if err != nil {
-		return "", err
-	}
-	if createResp.StatusCode < 200 || createResp.StatusCode >= 300 {
-		return "", fmt.Errorf("%s: %s", createResp.Status, client.SummarizeAPIErrors(createResp.Body))
-	}
-	var created struct {
-		Data struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(createResp.Body, &created); err != nil {
-		return "", err
-	}
-	if created.Data.ID == "" {
-		return "", fmt.Errorf("created variable set %q returned no id", opts.VariableSetName)
-	}
-	return created.Data.ID, nil
-}
-
-func listExistingVariables(ctx context.Context, apiClient *client.Client, target *variableTarget) (map[string]existingVariable, error) {
-	endpoint, err := client.ResolveURL(*apiClient.BaseURL, target.Path)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := apiClient.RawRequest(ctx, &client.Request{Method: http.MethodGet, URL: endpoint, Headers: jsonAPIHeaders()})
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("%s: %s", resp.Status, client.SummarizeAPIErrors(resp.Body))
-	}
-	var payload struct {
-		Data []struct {
-			ID         string `json:"id"`
-			Attributes struct {
-				Key      string `json:"key"`
-				Category string `json:"category"`
-			} `json:"attributes"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
-		return nil, err
-	}
-	existing := make(map[string]existingVariable, len(payload.Data))
-	for _, item := range payload.Data {
-		existing[existingKey(item.Attributes.Key, item.Attributes.Category)] = existingVariable{ID: item.ID, Key: item.Attributes.Key, Category: item.Attributes.Category}
-	}
-	return existing, nil
-}
-
-func createVariable(ctx context.Context, apiClient *client.Client, target *variableTarget, variable terraformcfg.ImportedVariable) error {
-	endpoint, err := client.ResolveURL(*apiClient.BaseURL, target.Path)
-	if err != nil {
-		return err
-	}
-	body, err := json.Marshal(variablePayload(variable))
-	if err != nil {
-		return err
-	}
-	resp, err := apiClient.RawRequest(ctx, &client.Request{Method: http.MethodPost, URL: endpoint, Headers: jsonAPIHeaders(), Body: body})
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("%s: %s", resp.Status, client.SummarizeAPIErrors(resp.Body))
-	}
-	return nil
-}
-
-func updateVariable(ctx context.Context, apiClient *client.Client, target *variableTarget, variableID string, variable terraformcfg.ImportedVariable) error {
-	endpoint, err := client.ResolveURL(*apiClient.BaseURL, fmt.Sprintf(target.ItemPath, url.PathEscape(variableID)))
-	if err != nil {
-		return err
-	}
-	body, err := json.Marshal(variablePayload(variable))
-	if err != nil {
-		return err
-	}
-	resp, err := apiClient.RawRequest(ctx, &client.Request{Method: http.MethodPatch, URL: endpoint, Headers: jsonAPIHeaders(), Body: body})
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("%s: %s", resp.Status, client.SummarizeAPIErrors(resp.Body))
-	}
-	return nil
-}
-
-func variablePayload(variable terraformcfg.ImportedVariable) map[string]any {
-	return map[string]any{
-		"data": map[string]any{
-			"type": "vars",
-			"attributes": map[string]any{
-				"key":       variable.Key,
-				"value":     variable.Value,
-				"category":  variable.Category,
-				"hcl":       variable.HCL,
-				"sensitive": variable.Sensitive,
-			},
-		},
-	}
-}
-
-func existingKey(key, category string) string {
-	return category + "\x00" + key
-}
-
-func jsonAPIHeaders() http.Header {
-	return http.Header{
-		"Accept":       []string{"application/vnd.api+json"},
-		"Content-Type": []string{"application/vnd.api+json"},
-	}
+	return newWorkspaceVariableTarget(apiClient, *workspace.GetData().GetId(), opts.Workspace), nil
 }

--- a/internal/commands/variable/variable_import_test.go
+++ b/internal/commands/variable/variable_import_test.go
@@ -1,0 +1,417 @@
+package variable
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/tfcloud/internal/pkg/client"
+	"github.com/hashicorp/tfcloud/internal/pkg/cmd"
+	"github.com/hashicorp/tfcloud/internal/pkg/iostreams"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunVariable_ImportWorkspaceFromTFVarsFile(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newVariableImportTestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/organizations/test-org/workspaces/test-workspace": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": map[string]any{"id": "ws-123", "type": "workspaces"},
+			})
+		},
+		"GET /api/v2/workspaces/ws-123/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{"data": []any{}})
+		},
+		"POST /api/v2/workspaces/ws-123/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{"id": "var-created", "type": "vars"},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	tfvars := writeTestTFVarsFile(t, "example = \"value\"\ncount = 3\n")
+
+	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+		opts.Organization = "test-org"
+		opts.Workspace = "test-workspace"
+		opts.TFVarsFileToImport = tfvars
+	}))
+	require.NoError(t, err)
+
+	reqs := recorder.All()
+	require.Len(t, reqs, 4)
+	require.Equal(t, "GET", reqs[0].Method)
+	require.Equal(t, "/api/v2/organizations/test-org/workspaces/test-workspace", reqs[0].Path)
+	require.Equal(t, "GET", reqs[1].Method)
+	require.Equal(t, "/api/v2/workspaces/ws-123/vars", reqs[1].Path)
+	requireRequestPayloads(t, reqs[2:], "POST", "/api/v2/workspaces/ws-123/vars", []map[string]any{
+		{
+			"data": map[string]any{
+				"attributes": map[string]any{
+					"category":  "terraform",
+					"hcl":       false,
+					"key":       "example",
+					"sensitive": false,
+					"value":     "value",
+				},
+			},
+		},
+		{
+			"data": map[string]any{
+				"attributes": map[string]any{
+					"category":  "terraform",
+					"hcl":       false,
+					"key":       "count",
+					"sensitive": false,
+					"value":     "3",
+				},
+			},
+		},
+	})
+
+	require.Equal(t, fmt.Sprintf("%s imported 2 variables into workspace \"test-workspace\" (2 created, 0 updated)", io.ColorScheme().SuccessIcon()), io.Error.String())
+}
+
+func TestRunVariable_ImportVariableSetFromEnv(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "secret-value")
+
+	server, recorder := newVariableImportTestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/organizations/test-org/varsets?q=my-set": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":         "vs-123",
+						"type":       "varsets",
+						"attributes": map[string]any{"name": "my-set"},
+					},
+				},
+			})
+		},
+		"GET /api/v2/varsets/vs-123/relationships/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{"data": []any{}})
+		},
+		"POST /api/v2/varsets/vs-123/relationships/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{"id": "var-created", "type": "vars"},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+		opts.Organization = "test-org"
+		opts.VariableSetName = "my-set"
+		opts.Env = []string{"AWS_ACCESS_KEY_ID"}
+	}))
+	require.NoError(t, err)
+
+	reqs := recorder.All()
+	require.Len(t, reqs, 3)
+	payload := jsonMap(t, string(reqs[2].Body))
+	require.Equal(t, map[string]any{
+		"data": map[string]any{
+			"attributes": map[string]any{
+				"category":  "env",
+				"hcl":       false,
+				"key":       "AWS_ACCESS_KEY_ID",
+				"sensitive": true,
+				"value":     "secret-value",
+			},
+		},
+	}, payload)
+	require.Equal(t, fmt.Sprintf("%s imported 1 variables into variable set \"my-set\" (1 created, 0 updated)", io.ColorScheme().SuccessIcon()), io.Error.String())
+}
+
+func TestRunVariable_ImportReturnsUsageWhenNothingToImport(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	err := runVariableImport(context.Background(), &ImportOpts{IO: io})
+	require.ErrorIs(t, err, cmd.ErrDisplayUsage)
+	require.Empty(t, io.Error.String())
+}
+
+func TestRunVariable_ImportErrorsWhenEnvVarMissing(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	err := runVariableImport(context.Background(), &ImportOpts{
+		IO:  io,
+		Env: []string{"MISSING_ENV"},
+	})
+	require.EqualError(t, err, "environment variable \"MISSING_ENV\" is not set")
+	require.Empty(t, io.Error.String())
+}
+
+func TestRunVariable_ImportErrorsOnDuplicateWithoutOverwrite(t *testing.T) {
+	t.Setenv("DUPLICATE_ENV", "new-value")
+
+	server, recorder := newVariableImportTestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/organizations/test-org/workspaces/test-workspace": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": map[string]any{"id": "ws-123", "type": "workspaces"},
+			})
+		},
+		"GET /api/v2/workspaces/ws-123/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":   "var-1",
+						"type": "vars",
+						"attributes": map[string]any{
+							"key":      "DUPLICATE_ENV",
+							"category": "env",
+						},
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+		opts.Organization = "test-org"
+		opts.Workspace = "test-workspace"
+		opts.Env = []string{"DUPLICATE_ENV"}
+	}))
+	require.EqualError(t, err, "variables already exist; rerun with --overwrite to update: DUPLICATE_ENV (env)")
+	require.Len(t, recorder.All(), 2)
+	require.Empty(t, io.Error.String())
+}
+
+func TestRunVariable_ImportOverwriteUpdatesExistingVariables(t *testing.T) {
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "updated-secret")
+
+	server, recorder := newVariableImportTestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/organizations/test-org/varsets?q=my-set": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":         "vs-123",
+						"type":       "varsets",
+						"attributes": map[string]any{"name": "my-set"},
+					},
+				},
+			})
+		},
+		"GET /api/v2/varsets/vs-123/relationships/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":   "var-99",
+						"type": "vars",
+						"attributes": map[string]any{
+							"key":      "AWS_SECRET_ACCESS_KEY",
+							"category": "env",
+						},
+					},
+				},
+			})
+		},
+		"PATCH /api/v2/varsets/vs-123/relationships/vars/var-99": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": map[string]any{"id": "var-99", "type": "vars"},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+		opts.Organization = "test-org"
+		opts.VariableSetName = "my-set"
+		opts.Env = []string{"AWS_SECRET_ACCESS_KEY"}
+		opts.Overwrite = true
+	}))
+	require.NoError(t, err)
+
+	reqs := recorder.All()
+	require.Len(t, reqs, 3)
+	payload := jsonMap(t, string(reqs[2].Body))
+	require.Equal(t, map[string]any{
+		"data": map[string]any{
+			"attributes": map[string]any{
+				"category":  "env",
+				"hcl":       false,
+				"key":       "AWS_SECRET_ACCESS_KEY",
+				"sensitive": true,
+				"value":     "updated-secret",
+			},
+		},
+	}, payload)
+	require.Equal(t, fmt.Sprintf("%s imported 1 variables into variable set \"my-set\" (0 created, 1 updated)", io.ColorScheme().SuccessIcon()), io.Error.String())
+}
+
+type variableImportRecordedRequest struct {
+	Method  string
+	Path    string
+	Query   string
+	Headers http.Header
+	Body    []byte
+}
+
+type variableImportRequestRecorder struct {
+	mu       sync.Mutex
+	requests []variableImportRecordedRequest
+}
+
+func (r *variableImportRequestRecorder) Record(req variableImportRecordedRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req)
+}
+
+func (r *variableImportRequestRecorder) All() []variableImportRecordedRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	requests := make([]variableImportRecordedRequest, len(r.requests))
+	copy(requests, r.requests)
+	return requests
+}
+
+func newVariableImportTestServer(routes map[string]http.HandlerFunc) (*httptest.Server, *variableImportRequestRecorder) {
+	recorder := &variableImportRequestRecorder{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		recorder.Record(variableImportRecordedRequest{
+			Method:  r.Method,
+			Path:    r.URL.Path,
+			Query:   r.URL.RawQuery,
+			Headers: r.Header.Clone(),
+			Body:    body,
+		})
+
+		key := variableImportRouteKey(r)
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+
+		http.Error(w, "unexpected request "+key, http.StatusInternalServerError)
+	})
+
+	return httptest.NewServer(handler), recorder
+}
+
+func variableImportRouteKey(r *http.Request) string {
+	if r.URL.RawQuery == "" {
+		return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+	}
+	return fmt.Sprintf("%s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+}
+
+func newImportTestOpts(t *testing.T, address string, io *iostreams.Testing, mutate func(*ImportOpts)) *ImportOpts {
+	t.Helper()
+	apiClient, err := client.New(address, "test-token", http.Header{
+		"User-Agent": []string{"tfcloud-cli/test"},
+	})
+	require.NoError(t, err)
+
+	opts := &ImportOpts{
+		IO:     io,
+		Client: apiClient,
+	}
+	if mutate != nil {
+		mutate(opts)
+	}
+	return opts
+}
+
+func writeTestTFVarsFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "variables.tfvars")
+	err := os.WriteFile(path, []byte(contents), 0o600)
+	require.NoError(t, err)
+	return path
+}
+
+func jsonMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &payload))
+	return payload
+}
+
+func requireRequestPayloads(t *testing.T, reqs []variableImportRecordedRequest, method, path string, want []map[string]any) {
+	t.Helper()
+
+	got := make([]string, 0, len(reqs))
+	for _, req := range reqs {
+		require.Equal(t, method, req.Method)
+		require.Equal(t, path, req.Path)
+
+		payload, err := json.Marshal(jsonMap(t, string(req.Body)))
+		require.NoError(t, err)
+		got = append(got, string(payload))
+	}
+
+	wantPayloads := make([]string, 0, len(want))
+	for _, payload := range want {
+		encoded, err := json.Marshal(payload)
+		require.NoError(t, err)
+		wantPayloads = append(wantPayloads, string(encoded))
+	}
+
+	require.ElementsMatch(t, wantPayloads, got)
+}
+
+func writeJSONAPIResponse(w http.ResponseWriter, status int, payload map[string]any) {
+	w.Header().Set("Content-Type", "application/vnd.api+json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func TestRunVariable_ImportParsesJSONTFVarsFile(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newVariableImportTestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/organizations/test-org/workspaces/test-workspace": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": map[string]any{"id": "ws-123", "type": "workspaces"},
+			})
+		},
+		"GET /api/v2/workspaces/ws-123/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{"data": []any{}})
+		},
+		"POST /api/v2/workspaces/ws-123/vars": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{"id": "var-created", "type": "vars"},
+			})
+		},
+	})
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "variables.tfvars.json")
+	err := os.WriteFile(path, []byte(`{"enabled":true}`), 0o600)
+	require.NoError(t, err)
+
+	io := iostreams.Test()
+	err = runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+		opts.Organization = "test-org"
+		opts.Workspace = "test-workspace"
+		opts.TFVarsFileToImport = path
+	}))
+	require.NoError(t, err)
+
+	reqs := recorder.All()
+	require.Len(t, reqs, 3)
+	require.True(t, strings.Contains(string(reqs[2].Body), `"key":"enabled"`))
+	require.True(t, strings.Contains(string(reqs[2].Body), `"value":"true"`))
+}

--- a/internal/commands/variable/variable_import_test.go
+++ b/internal/commands/variable/variable_import_test.go
@@ -42,7 +42,7 @@ func TestRunVariable_ImportWorkspaceFromTFVarsFile(t *testing.T) {
 	io := iostreams.Test()
 	tfvars := writeTestTFVarsFile(t, "example = \"value\"\ncount = 3\n")
 
-	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+	err := runVariableImport(newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
 		opts.Organization = "test-org"
 		opts.Workspace = "test-workspace"
 		opts.TFVarsFileToImport = tfvars
@@ -110,7 +110,7 @@ func TestRunVariable_ImportVariableSetFromEnv(t *testing.T) {
 	defer server.Close()
 
 	io := iostreams.Test()
-	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+	err := runVariableImport(newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
 		opts.Organization = "test-org"
 		opts.VariableSetName = "my-set"
 		opts.Env = []string{"AWS_ACCESS_KEY_ID"}
@@ -138,7 +138,7 @@ func TestRunVariable_ImportReturnsUsageWhenNothingToImport(t *testing.T) {
 	t.Parallel()
 
 	io := iostreams.Test()
-	err := runVariableImport(context.Background(), &ImportOpts{IO: io})
+	err := runVariableImport(&ImportOpts{IO: io})
 	require.ErrorIs(t, err, cmd.ErrDisplayUsage)
 	require.Empty(t, io.Error.String())
 }
@@ -147,7 +147,7 @@ func TestRunVariable_ImportErrorsWhenEnvVarMissing(t *testing.T) {
 	t.Parallel()
 
 	io := iostreams.Test()
-	err := runVariableImport(context.Background(), &ImportOpts{
+	err := runVariableImport(&ImportOpts{
 		IO:  io,
 		Env: []string{"MISSING_ENV"},
 	})
@@ -182,7 +182,7 @@ func TestRunVariable_ImportErrorsOnDuplicateWithoutOverwrite(t *testing.T) {
 	defer server.Close()
 
 	io := iostreams.Test()
-	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+	err := runVariableImport(newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
 		opts.Organization = "test-org"
 		opts.Workspace = "test-workspace"
 		opts.Env = []string{"DUPLICATE_ENV"}
@@ -230,7 +230,7 @@ func TestRunVariable_ImportOverwriteUpdatesExistingVariables(t *testing.T) {
 	defer server.Close()
 
 	io := iostreams.Test()
-	err := runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+	err := runVariableImport(newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
 		opts.Organization = "test-org"
 		opts.VariableSetName = "my-set"
 		opts.Env = []string{"AWS_SECRET_ACCESS_KEY"}
@@ -325,8 +325,9 @@ func newImportTestOpts(t *testing.T, address string, io *iostreams.Testing, muta
 	require.NoError(t, err)
 
 	opts := &ImportOpts{
-		IO:     io,
-		Client: apiClient,
+		IO:          io,
+		ShutdownCtx: context.Background(),
+		Client:      apiClient,
 	}
 	if mutate != nil {
 		mutate(opts)
@@ -403,7 +404,7 @@ func TestRunVariable_ImportParsesJSONTFVarsFile(t *testing.T) {
 	require.NoError(t, err)
 
 	io := iostreams.Test()
-	err = runVariableImport(context.Background(), newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
+	err = runVariableImport(newImportTestOpts(t, server.URL, io, func(opts *ImportOpts) {
 		opts.Organization = "test-org"
 		opts.Workspace = "test-workspace"
 		opts.TFVarsFileToImport = path

--- a/internal/commands/variable/variable_import_test.go
+++ b/internal/commands/variable/variable_import_test.go
@@ -13,10 +13,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/tfcloud/internal/pkg/client"
 	"github.com/hashicorp/tfcloud/internal/pkg/cmd"
 	"github.com/hashicorp/tfcloud/internal/pkg/iostreams"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRunVariable_ImportWorkspaceFromTFVarsFile(t *testing.T) {

--- a/internal/pkg/client/helpers.go
+++ b/internal/pkg/client/helpers.go
@@ -1,0 +1,112 @@
+package client
+
+import (
+	"github.com/hashicorp/go-tfe/api/organizations"
+	"github.com/hashicorp/go-tfe/api/varsets"
+	"github.com/hashicorp/go-tfe/api/workspaces"
+)
+
+// NewVarsetsVarsPostBody creates a new varsets.ItemRelationshipsVarsPostRequestBody
+// from parameters.
+func NewVarsetsVarsPostBody(key, value, category string, sensitive bool) *varsets.ItemRelationshipsVarsPostRequestBody {
+	hcl := false
+	attrib := &varsets.ItemRelationshipsVarsPostRequestBody_data_attributes{}
+	attrib.SetKey(&key)
+	attrib.SetValue(&value)
+	attrib.SetSensitive(&sensitive)
+	attrib.SetHcl(&hcl)
+
+	props := make(map[string]any)
+	props["category"] = category
+
+	attrib.SetAdditionalData(props)
+
+	data := &varsets.ItemRelationshipsVarsPostRequestBody_data{}
+	data.SetAttributes(attrib)
+	body := &varsets.ItemRelationshipsVarsPostRequestBody{}
+	body.SetData(data)
+
+	return body
+}
+
+// NewVarsetsVarsPatchBody creates a new varsets.ItemRelationshipsVarsItemVarsPatchRequestBody
+// from parameters.
+func NewVarsetsVarsPatchBody(key, value, category string, sensitive bool) *varsets.ItemRelationshipsVarsItemVarsPatchRequestBody {
+	hcl := false
+	attrib := &varsets.ItemRelationshipsVarsItemVarsPatchRequestBody_data_attributes{}
+	attrib.SetKey(&key)
+	attrib.SetValue(&value)
+	attrib.SetSensitive(&sensitive)
+	attrib.SetHcl(&hcl)
+
+	props := make(map[string]any)
+	props["category"] = category
+
+	attrib.SetAdditionalData(props)
+
+	data := &varsets.ItemRelationshipsVarsItemVarsPatchRequestBody_data{}
+	data.SetAttributes(attrib)
+	body := &varsets.ItemRelationshipsVarsItemVarsPatchRequestBody{}
+	body.SetData(data)
+
+	return body
+}
+
+// NewWorkspacesVarsPostBody creates a new workspaces.ItemVarsPostRequestBody from parameters.
+func NewWorkspacesVarsPostBody(key, value, category string, sensitive bool) *workspaces.ItemVarsPostRequestBody {
+	hcl := false
+	attrib := &workspaces.ItemVarsPostRequestBody_data_attributes{}
+	attrib.SetKey(&key)
+	attrib.SetValue(&value)
+	attrib.SetSensitive(&sensitive)
+	attrib.SetHcl(&hcl)
+
+	props := make(map[string]any)
+	props["category"] = category
+
+	attrib.SetAdditionalData(props)
+
+	data := &workspaces.ItemVarsPostRequestBody_data{}
+	data.SetAttributes(attrib)
+	body := &workspaces.ItemVarsPostRequestBody{}
+	body.SetData(data)
+
+	return body
+}
+
+// NewWorkspacesVarsPatchBody creates a new workspaces.ItemVarsItemVarsPatchRequestBody
+// from parameters.
+func NewWorkspacesVarsPatchBody(key, value, category string, sensitive bool) *workspaces.ItemVarsItemVarsPatchRequestBody {
+	hcl := false
+	attrib := &workspaces.ItemVarsItemVarsPatchRequestBody_data_attributes{}
+	attrib.SetKey(&key)
+	attrib.SetValue(&value)
+	attrib.SetSensitive(&sensitive)
+	attrib.SetHcl(&hcl)
+
+	props := make(map[string]any)
+	props["category"] = category
+
+	attrib.SetAdditionalData(props)
+
+	data := &workspaces.ItemVarsItemVarsPatchRequestBody_data{}
+	data.SetAttributes(attrib)
+	body := &workspaces.ItemVarsItemVarsPatchRequestBody{}
+	body.SetData(data)
+
+	return body
+}
+
+// NewOrganizationsVarsetsPostBody creates a new organizations.ItemVarsetsPostRequestBody
+// from parameters.
+func NewOrganizationsVarsetsPostBody(variableSetName string) *organizations.ItemVarsetsPostRequestBody {
+	attrib := &organizations.ItemVarsetsPostRequestBody_data_attributes{}
+	attrib.SetName(&variableSetName)
+
+	data := &organizations.ItemVarsetsPostRequestBody_data{}
+	data.SetAttributes(attrib)
+	body := &organizations.ItemVarsetsPostRequestBody{}
+	body.SetData(data)
+
+	return body
+}

--- a/internal/pkg/client/helpers.go
+++ b/internal/pkg/client/helpers.go
@@ -2,47 +2,46 @@ package client
 
 import (
 	"github.com/hashicorp/go-tfe/api/models"
-	"github.com/hashicorp/go-tfe/api/organizations"
 )
 
 // NewVarRequest creates a new varsets.ItemRelationshipsVarsPostRequestBody
 // from parameters.
-func NewVarRequest(key, value, category string, sensitive bool) models.VarEnvelopeable {
+func NewVarRequest(key, value, category string, sensitive bool) models.VarsEnvelopeable {
 	hcl := false
-	attrib := &models.Var_attributes{}
+	attrib := &models.Vars_attributes{}
 	attrib.SetKey(&key)
 	attrib.SetValue(&value)
 	attrib.SetSensitive(&sensitive)
 	attrib.SetHcl(&hcl)
 	attrib.SetCategory(mustParseCategory(category))
 
-	data := &models.VarEscaped{}
+	data := &models.Vars{}
 	data.SetAttributes(attrib)
 
-	body := models.NewVarEnvelope()
+	body := models.NewVarsEnvelope()
 	body.SetData(data)
 
 	return body
 }
 
-func mustParseCategory(category string) *models.Var_attributes_category {
-	cat, err := models.ParseVar_attributes_category(category)
+func mustParseCategory(category string) *models.Vars_attributes_category {
+	cat, err := models.ParseVars_attributes_category(category)
 	if err != nil {
 		panic("cannot parse category \"" + category + "\"")
 	}
-	result := cat.(*models.Var_attributes_category)
+	result := cat.(*models.Vars_attributes_category)
 	return result
 }
 
 // NewOrganizationsVarsetsPostBody creates a new organizations.ItemVarsetsPostRequestBody
 // from parameters.
-func NewOrganizationsVarsetsPostBody(variableSetName string) *organizations.ItemVarsetsPostRequestBody {
-	attrib := &organizations.ItemVarsetsPostRequestBody_data_attributes{}
+func NewOrganizationsVarsetsPostBody(variableSetName string) *models.VarsetsEnvelope {
+	attrib := &models.Varsets_attributes{}
 	attrib.SetName(&variableSetName)
 
-	data := &organizations.ItemVarsetsPostRequestBody_data{}
+	data := &models.Varsets{}
 	data.SetAttributes(attrib)
-	body := &organizations.ItemVarsetsPostRequestBody{}
+	body := &models.VarsetsEnvelope{}
 	body.SetData(data)
 
 	return body

--- a/internal/pkg/client/helpers.go
+++ b/internal/pkg/client/helpers.go
@@ -1,100 +1,37 @@
 package client
 
 import (
+	"github.com/hashicorp/go-tfe/api/models"
 	"github.com/hashicorp/go-tfe/api/organizations"
-	"github.com/hashicorp/go-tfe/api/varsets"
-	"github.com/hashicorp/go-tfe/api/workspaces"
 )
 
-// NewVarsetsVarsPostBody creates a new varsets.ItemRelationshipsVarsPostRequestBody
+// NewVarRequest creates a new varsets.ItemRelationshipsVarsPostRequestBody
 // from parameters.
-func NewVarsetsVarsPostBody(key, value, category string, sensitive bool) *varsets.ItemRelationshipsVarsPostRequestBody {
+func NewVarRequest(key, value, category string, sensitive bool) models.VarEnvelopeable {
 	hcl := false
-	attrib := &varsets.ItemRelationshipsVarsPostRequestBody_data_attributes{}
+	attrib := &models.Var_attributes{}
 	attrib.SetKey(&key)
 	attrib.SetValue(&value)
 	attrib.SetSensitive(&sensitive)
 	attrib.SetHcl(&hcl)
+	attrib.SetCategory(mustParseCategory(category))
 
-	props := make(map[string]any)
-	props["category"] = category
-
-	attrib.SetAdditionalData(props)
-
-	data := &varsets.ItemRelationshipsVarsPostRequestBody_data{}
+	data := &models.VarEscaped{}
 	data.SetAttributes(attrib)
-	body := &varsets.ItemRelationshipsVarsPostRequestBody{}
+
+	body := models.NewVarEnvelope()
 	body.SetData(data)
 
 	return body
 }
 
-// NewVarsetsVarsPatchBody creates a new varsets.ItemRelationshipsVarsItemVarsPatchRequestBody
-// from parameters.
-func NewVarsetsVarsPatchBody(key, value, category string, sensitive bool) *varsets.ItemRelationshipsVarsItemVarsPatchRequestBody {
-	hcl := false
-	attrib := &varsets.ItemRelationshipsVarsItemVarsPatchRequestBody_data_attributes{}
-	attrib.SetKey(&key)
-	attrib.SetValue(&value)
-	attrib.SetSensitive(&sensitive)
-	attrib.SetHcl(&hcl)
-
-	props := make(map[string]any)
-	props["category"] = category
-
-	attrib.SetAdditionalData(props)
-
-	data := &varsets.ItemRelationshipsVarsItemVarsPatchRequestBody_data{}
-	data.SetAttributes(attrib)
-	body := &varsets.ItemRelationshipsVarsItemVarsPatchRequestBody{}
-	body.SetData(data)
-
-	return body
-}
-
-// NewWorkspacesVarsPostBody creates a new workspaces.ItemVarsPostRequestBody from parameters.
-func NewWorkspacesVarsPostBody(key, value, category string, sensitive bool) *workspaces.ItemVarsPostRequestBody {
-	hcl := false
-	attrib := &workspaces.ItemVarsPostRequestBody_data_attributes{}
-	attrib.SetKey(&key)
-	attrib.SetValue(&value)
-	attrib.SetSensitive(&sensitive)
-	attrib.SetHcl(&hcl)
-
-	props := make(map[string]any)
-	props["category"] = category
-
-	attrib.SetAdditionalData(props)
-
-	data := &workspaces.ItemVarsPostRequestBody_data{}
-	data.SetAttributes(attrib)
-	body := &workspaces.ItemVarsPostRequestBody{}
-	body.SetData(data)
-
-	return body
-}
-
-// NewWorkspacesVarsPatchBody creates a new workspaces.ItemVarsItemVarsPatchRequestBody
-// from parameters.
-func NewWorkspacesVarsPatchBody(key, value, category string, sensitive bool) *workspaces.ItemVarsItemVarsPatchRequestBody {
-	hcl := false
-	attrib := &workspaces.ItemVarsItemVarsPatchRequestBody_data_attributes{}
-	attrib.SetKey(&key)
-	attrib.SetValue(&value)
-	attrib.SetSensitive(&sensitive)
-	attrib.SetHcl(&hcl)
-
-	props := make(map[string]any)
-	props["category"] = category
-
-	attrib.SetAdditionalData(props)
-
-	data := &workspaces.ItemVarsItemVarsPatchRequestBody_data{}
-	data.SetAttributes(attrib)
-	body := &workspaces.ItemVarsItemVarsPatchRequestBody{}
-	body.SetData(data)
-
-	return body
+func mustParseCategory(category string) *models.Var_attributes_category {
+	cat, err := models.ParseVar_attributes_category(category)
+	if err != nil {
+		panic("cannot parse category \"" + category + "\"")
+	}
+	result := cat.(*models.Var_attributes_category)
+	return result
 }
 
 // NewOrganizationsVarsetsPostBody creates a new organizations.ItemVarsetsPostRequestBody

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe/api/organizations"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+)
+
+// Resolver abstracts helpers for resolving resources by name, with options for creating the
+// the resource if it does not exist.
+type Resolver struct {
+	client           *Client
+	createIfNotFound bool
+	dryRun           bool
+}
+
+// NewResolver creates a new Resolver.
+func NewResolver(client *Client, createIfNotFound, dryRun bool) *Resolver {
+	return &Resolver{
+		client:           client,
+		createIfNotFound: createIfNotFound,
+		dryRun:           dryRun,
+	}
+}
+
+// VariableSet resolves a variable set by organization + name.
+func (r Resolver) VariableSet(ctx context.Context, organization, name string) (*string, error) {
+	requestConfig := &abstractions.RequestConfiguration[organizations.ItemVarsetsRequestBuilderGetQueryParameters]{
+		QueryParameters: &organizations.ItemVarsetsRequestBuilderGetQueryParameters{
+			Q: &name,
+		},
+	}
+
+	items, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Varsets().Get(ctx, requestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items.GetData() {
+		att := item.GetAttributes()
+		if *att.GetName() == name {
+			return item.GetId(), nil
+		}
+	}
+
+	if r.createIfNotFound {
+		// Create the Variable Set
+		created, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Varsets().Post(ctx, NewOrganizationsVarsetsPostBody(name), nil)
+		if err != nil {
+			return nil, fmt.Errorf("variable set named %q could not be created: %w", name, err)
+		}
+
+		return created.GetData().GetId(), nil
+	}
+
+	return nil, fmt.Errorf("variable set named %q was not found", name)
+}

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	example "github.com/hashicorp/go-tfe/api/account"
+	models "github.com/hashicorp/go-tfe/api/models"
 
 	"github.com/hashicorp/tfcloud/internal/pkg/format"
 	"github.com/hashicorp/tfcloud/internal/pkg/iostreams"
@@ -166,7 +166,7 @@ func TestWithSlice(t *testing.T) {
     }
   }
 }`
-	thing := example.DetailsGetResponse{}
+	thing := models.UsersEnvelope{}
 	err := json.Unmarshal([]byte(j), &thing)
 	r.NoError(err)
 	io := iostreams.Test()


### PR DESCRIPTION
## Description

Refactors the `variable import` command:
- Change raw requests to strongly typed requests in the client
- Extracted resolvers for resolving resources by name
- Created helpers for creating request bodies using parameters
- Separated Runf into a run function to simplify testing

Adds unit tests for `variable import` usage

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
