### PR TITLE
Add --jq flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/go-tfe v1.78.1-0.20260423211818-e37f9ff614bd
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
+	github.com/itchyny/gojq v0.12.19
 	github.com/lithammer/dedent v1.1.0
 	github.com/microsoft/kiota-abstractions-go v1.9.4
 	github.com/mitchellh/go-homedir v1.1.0
@@ -52,6 +53,8 @@ require (
 	github.com/blugelabs/ice/v2 v2.0.1 // indirect
 	github.com/caio/go-tdigest v3.1.0+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/clipperhouse/stringish v0.1.1 // indirect
+	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/fatih/color v1.18.0 // indirect
@@ -62,11 +65,12 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/klauspost/compress v1.15.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/microsoft/kiota-http-go v1.5.5 // indirect
 	github.com/microsoft/kiota-serialization-form-go v1.1.3 // indirect
 	github.com/microsoft/kiota-serialization-json-go v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,10 @@ github.com/caio/go-tdigest v3.1.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
+github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
+github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
+github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -111,6 +115,10 @@ github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
+github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
+github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
+github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
+github.com/itchyny/timefmt-go v0.1.8/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/klauspost/compress v1.15.2 h1:3WH+AG7s2+T8o3nrM/8u2rdqUEcQhmga7smjrT41nAw=
 github.com/klauspost/compress v1.15.2/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
@@ -135,8 +143,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
-github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
+github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microsoft/kiota-abstractions-go v1.9.4 h1:VI3UVzSCQHHhRswe3jyaAQHUQWIFhUMp0z5mtZbTbcs=
 github.com/microsoft/kiota-abstractions-go v1.9.4/go.mod h1:f06pl3qSyvUHEfVNkiRpXPkafx7khZqQEb71hN/pmuU=
 github.com/microsoft/kiota-http-go v1.5.5 h1:K+jC3lq0kejeUETmh/C7TSIV+vdLuw1LT7NPPoNCxAE=

--- a/internal/pkg/cmd/context.go
+++ b/internal/pkg/cmd/context.go
@@ -214,7 +214,7 @@ func (ctx *Context) applyGlobalFlags(c *Command) error {
 
 	// Set the output format if the flag is set.
 	f := format.Unset
-	if ctx.flags.json || ctx.flags.jq != "" {
+	if ctx.flags.json {
 		f = format.JSON
 	}
 	if ctx.flags.agent {
@@ -228,12 +228,19 @@ func (ctx *Context) applyGlobalFlags(c *Command) error {
 		}
 	}
 
-	if f != format.Unset {
-		ctx.Output.SetFormat(f)
+	// --jq implies --json and is only compatible with --json or --agent
+	if ctx.flags.jq != "" {
+		if f == format.Markdown {
+			return fmt.Errorf("--jq cannot be used with --markdown; only --json or --agent output is supported")
+		}
+		if f == format.Unset {
+			f = format.JSON
+		}
+		ctx.Output.SetJQFilter(ctx.flags.jq)
 	}
 
-	if ctx.flags.jq != "" {
-		ctx.Output.SetJQFilter(ctx.flags.jq)
+	if f != format.Unset {
+		ctx.Output.SetFormat(f)
 	}
 
 	// Disable color if set

--- a/internal/pkg/cmd/context.go
+++ b/internal/pkg/cmd/context.go
@@ -54,6 +54,7 @@ type GlobalFlags struct {
 	agent    bool
 	markdown bool
 	noColor  bool
+	jq       string
 	debug    int
 
 	// Version indicates the user has requested the version of the CLI
@@ -99,6 +100,12 @@ func ConfigureRootCommand(ctx *Context, cmd *Command) {
 
 			return profiles
 		}),
+	}, &Flag{
+		Name:         "jq",
+		DisplayValue: "EXPRESSION",
+		Description:  "A jq filter expression to apply to JSON output. Implies --json.",
+		Value:        flagvalue.Simple("", &ctx.flags.jq),
+		global:       true,
 	}, &Flag{
 		Name:          "json",
 		Description:   "Sets the output format.",
@@ -207,7 +214,7 @@ func (ctx *Context) applyGlobalFlags(c *Command) error {
 
 	// Set the output format if the flag is set.
 	f := format.Unset
-	if ctx.flags.json {
+	if ctx.flags.json || ctx.flags.jq != "" {
 		f = format.JSON
 	}
 	if ctx.flags.agent {
@@ -223,6 +230,10 @@ func (ctx *Context) applyGlobalFlags(c *Command) error {
 
 	if f != format.Unset {
 		ctx.Output.SetFormat(f)
+	}
+
+	if ctx.flags.jq != "" {
+		ctx.Output.SetJQFilter(ctx.flags.jq)
 	}
 
 	// Disable color if set

--- a/internal/pkg/format/json_test.go
+++ b/internal/pkg/format/json_test.go
@@ -114,6 +114,64 @@ func TestJSON_Complex_Slice(t *testing.T) {
 	r.Equal(d.Data, parsed)
 }
 
+func TestJSON_JQFilter_Field(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	io := iostreams.Test()
+	out := format.New(io)
+	out.SetFormat(format.JSON)
+	out.SetJQFilter(".Key")
+
+	d := &KVDisplayer{
+		KVs: []*KV{
+			{
+				Key:   "Hello",
+				Value: "World!",
+			},
+		},
+		Default: format.JSON,
+	}
+
+	r.NoError(out.Display(d))
+	r.Equal("\"Hello\"\n", io.Output.String())
+}
+
+func TestJSON_JQFilter_Array(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	io := iostreams.Test()
+	out := format.New(io)
+	out.SetFormat(format.JSON)
+	out.SetJQFilter(".[].Key")
+
+	d := &KVDisplayer{
+		KVs: []*KV{
+			{Key: "First", Value: "A"},
+			{Key: "Second", Value: "B"},
+		},
+		Default: format.JSON,
+	}
+
+	r.NoError(out.Display(d))
+	r.Equal("\"First\"\n\"Second\"\n", io.Output.String())
+}
+
+func TestJSON_JQFilter_InvalidExpression(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	io := iostreams.Test()
+	out := format.New(io)
+	out.SetFormat(format.JSON)
+	out.SetJQFilter("invalid[[[")
+
+	d := &KVDisplayer{
+		KVs:     []*KV{{Key: "Hello", Value: "World!"}},
+		Default: format.JSON,
+	}
+
+	r.Error(out.Display(d))
+}
+
 func TestJSON_Complex_Struct(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)

--- a/internal/pkg/format/output.go
+++ b/internal/pkg/format/output.go
@@ -14,6 +14,8 @@ import (
 	"text/template"
 	"unicode"
 
+	"github.com/itchyny/gojq"
+
 	"github.com/hashicorp/tfcloud/internal/pkg/iostreams"
 )
 
@@ -277,6 +279,9 @@ type Outputter struct {
 	// forcedFormat is the format to output with regardless of the DefaultFormat
 	// of the passed Displayer.
 	forcedFormat Format
+
+	// jqFilter is an optional jq filter expression to apply to JSON output.
+	jqFilter string
 }
 
 // New returns an new outputter that will write to the provided IOStreams.
@@ -299,6 +304,11 @@ func (o *Outputter) SetFormat(f Format) {
 // GetFormat returns the format if set.
 func (o *Outputter) GetFormat() Format {
 	return o.forcedFormat
+}
+
+// SetJQFilter sets a jq filter expression to apply to JSON output.
+func (o *Outputter) SetJQFilter(filter string) {
+	o.jqFilter = filter
 }
 
 // Display displays the passed Displayer. The format used is the DefaultFormat
@@ -344,12 +354,61 @@ func (o *Outputter) Show(val any, format Format, fields ...string) error {
 
 // outputJSON outputs the payload in JSON.
 func (o *Outputter) outputJSON(d Displayer) error {
-	data, err := json.MarshalIndent(d.Payload(), "", "  ")
+	payload := d.Payload()
+
+	if o.jqFilter != "" {
+		return o.outputJSONWithJQ(payload)
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshall result to JSON: %w", err)
 	}
 
 	fmt.Fprintln(o.io.Out(), string(data))
+	return nil
+}
+
+// outputJSONWithJQ applies a jq filter to the payload and outputs the results.
+func (o *Outputter) outputJSONWithJQ(payload any) error {
+	query, err := gojq.Parse(o.jqFilter)
+	if err != nil {
+		return fmt.Errorf("failed to parse jq expression: %w", err)
+	}
+
+	code, err := gojq.Compile(query)
+	if err != nil {
+		return fmt.Errorf("failed to compile jq expression: %w", err)
+	}
+
+	// Convert payload to interface{} via JSON round-trip to ensure compatibility with gojq
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	var input interface{}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+
+	iter := code.Run(input)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, isErr := v.(error); isErr {
+			return fmt.Errorf("jq filter error: %w", err)
+		}
+
+		data, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal jq result: %w", err)
+		}
+		fmt.Fprintln(o.io.Out(), string(data))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Summary
Adds a global --jq flag that accepts a jq filter expression (e.g. `--jq '.[] | .name'`), implies --json, and uses the gojq package to filter JSON output before printing.
### Usage
Extract workspace names
`tfcloud workspaces list --jq '.[].name'`
Get a specific field from a single resource
`tfcloud workspaces show my-workspace --jq '.id'`

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
