### PR TITLE
Implement confirmation for API DELETE methods as a safety guardrail

### DIFF
--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -242,6 +242,24 @@ func runAPI(opts *Opts) error {
 		return nil
 	}
 
+	// Interactive prompt required for DELETE requests to prevent accidental data loss
+	if method == http.MethodDelete {
+		if opts.Quiet {
+			return errors.New("can't perform DELETE request confirmation with quiet mode enabled")
+		}
+		if !opts.IO.CanPrompt() {
+			return errors.New("can't perform DELETE request without confirmation in non-interactive mode")
+		}
+
+		confirmation, err := opts.IO.PromptConfirm("The request must be confirmed because it is a DELETE action.\n\nDo you want to continue")
+		if err != nil {
+			return fmt.Errorf("failed to confirm DELETE request: %w", err)
+		}
+		if !confirmation {
+			return errors.New("DELETE request canceled")
+		}
+	}
+
 	// Make the request
 	response, err := opts.Client.RawRequest(opts.ShutdownCtx, &client.Request{
 		Method:  method,

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -235,13 +235,6 @@ func runAPI(opts *Opts) error {
 		requestHeaders.Set("Accept", "application/vnd.api+json")
 	}
 
-	// In dry-run mode, skip mutating requests and report what would have happened.
-	if opts.DryRun && isMutationMethod(method) {
-		fmt.Fprintf(opts.IO.Err(), "%s would send %s %s\n", opts.IO.ColorScheme().DryRunLabel(), method, opts.URL.String())
-		writeDryRunRequest(opts.IO.Err(), method, opts.URL, requestHeaders, body)
-		return nil
-	}
-
 	// Interactive prompt required for DELETE requests to prevent accidental data loss
 	if method == http.MethodDelete {
 		if opts.Quiet {
@@ -251,13 +244,25 @@ func runAPI(opts *Opts) error {
 			return errors.New("can't perform DELETE request without confirmation in non-interactive mode")
 		}
 
-		confirmation, err := opts.IO.PromptConfirm("The request must be confirmed because it is a DELETE action.\n\nDo you want to continue")
+		dryRunWarning := ""
+		if opts.DryRun {
+			dryRunWarning = " (no actual request will be sent in dry-run mode)"
+		}
+
+		confirmation, err := opts.IO.PromptConfirm(fmt.Sprintf("The request must be confirmed because it is a DELETE action%s.\n\nDo you want to continue", dryRunWarning))
 		if err != nil {
 			return fmt.Errorf("failed to confirm DELETE request: %w", err)
 		}
 		if !confirmation {
 			return errors.New("DELETE request canceled")
 		}
+	}
+
+	// In dry-run mode, skip mutating requests and report what would have happened.
+	if opts.DryRun && isMutationMethod(method) {
+		fmt.Fprintf(opts.IO.Err(), "%s would send %s request\n", opts.IO.ColorScheme().DryRunLabel(), method)
+		writeDryRunRequest(opts.IO.Err(), method, opts.URL, requestHeaders, body)
+		return nil
 	}
 
 	// Make the request
@@ -548,7 +553,7 @@ func writeDryRunRequest(w io.Writer, method string, u *url.URL, headers http.Hea
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		fmt.Fprintf(w, "%s: %s\n", key, strings.Join(headers.Values(key), ", "))
+		fmt.Fprintf(w, "> %s: %s\n", key, strings.Join(headers.Values(key), ", "))
 	}
 	if len(body) == 0 {
 		return

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -322,7 +322,7 @@ func TestRunAPI_QuietSuppressesOutput(t *testing.T) {
 	require.Empty(t, io.Output.String())
 }
 
-func TestRunAPI_EmptyBodyReturnsNil(t *testing.T) {
+func TestRunAPI_EmptyBodyNoOutput(t *testing.T) {
 	t.Parallel()
 
 	server, _ := newAPITestServer(map[string]http.HandlerFunc{
@@ -334,12 +334,66 @@ func TestRunAPI_EmptyBodyReturnsNil(t *testing.T) {
 	defer server.Close()
 
 	io := iostreams.Test()
+	io.ErrorTTY = true
+	io.InputTTY = true
+	io.Input.Write([]byte("y\n"))
+
 	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
 		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-1")
 		opts.Method = http.MethodDelete
 	}))
 	require.NoError(t, err)
 	require.Empty(t, io.Output.String())
+}
+
+func TestRunAPI_DeleteNoConfirmation(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"DELETE /api/v2/workspaces/ws-1": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("{ \"data\": { \"attributes\": { \"hello\": \"world\" } } }"))
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	io.ErrorTTY = true
+	io.InputTTY = true
+	io.Input.Write([]byte("n\n"))
+
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-1")
+		opts.Method = http.MethodDelete
+	}))
+	require.ErrorContains(t, err, "DELETE request canceled")
+}
+
+func TestRunAPI_DeleteQuietMode(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"DELETE /api/v2/workspaces/ws-1": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("{ \"data\": { \"attributes\": { \"hello\": \"world\" } } }"))
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	io.ErrorTTY = true
+	io.InputTTY = true
+	io.SetQuiet(true)
+	io.Input.Write([]byte("y\n"))
+
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-1")
+		opts.Method = http.MethodDelete
+		opts.Quiet = true
+	}))
+	require.ErrorContains(t, err, "can't perform DELETE request confirmation with quiet mode enabled")
 }
 
 func TestRunAPI_ErrorResponseSummarizesJSONAPIErrors(t *testing.T) {

--- a/internal/commands/variable/target.go
+++ b/internal/commands/variable/target.go
@@ -90,9 +90,9 @@ func (t *variableTarget) createVariable(ctx context.Context, variable terraformc
 	var err error
 	switch t.Kind {
 	case kindVariableSet:
-		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().Post(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().Post(ctx, client.NewVar(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	case kindWorkspace:
-		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().Post(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().Post(ctx, client.NewVar(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	default:
 		return fmt.Errorf("unknown variable target kind %s, this is a bug in tfcloud", t.Kind)
 	}
@@ -104,9 +104,9 @@ func (t *variableTarget) updateVariable(ctx context.Context, variableID string, 
 	var err error
 	switch t.Kind {
 	case kindVariableSet:
-		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().ById(variableID).Patch(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Varsets().ByVarset_id(t.ID).Relationships().Vars().ById(variableID).Patch(ctx, client.NewVar(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	case kindWorkspace:
-		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().ById(variableID).Patch(ctx, client.NewVarRequest(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
+		_, err = t.apiClient.Workspaces().ByWorkspace_id(t.ID).Vars().ById(variableID).Patch(ctx, client.NewVar(variable.Key, variable.Value, variable.Category, variable.Sensitive), nil)
 	default:
 		return fmt.Errorf("unknown variable target kind %s, this is a bug in tfcloud", t.Kind)
 	}

--- a/internal/pkg/client/helpers.go
+++ b/internal/pkg/client/helpers.go
@@ -4,9 +4,8 @@ import (
 	"github.com/hashicorp/go-tfe/api/models"
 )
 
-// NewVarRequest creates a new varsets.ItemRelationshipsVarsPostRequestBody
-// from parameters.
-func NewVarRequest(key, value, category string, sensitive bool) models.VarsEnvelopeable {
+// NewVar creates a new models.VarsEnvelope for creating a variable from parameters.
+func NewVar(key, value, category string, sensitive bool) *models.VarsEnvelope {
 	hcl := false
 	attrib := &models.Vars_attributes{}
 	attrib.SetKey(&key)
@@ -18,7 +17,7 @@ func NewVarRequest(key, value, category string, sensitive bool) models.VarsEnvel
 	data := &models.Vars{}
 	data.SetAttributes(attrib)
 
-	body := models.NewVarsEnvelope()
+	body := &models.VarsEnvelope{}
 	body.SetData(data)
 
 	return body
@@ -33,14 +32,14 @@ func mustParseCategory(category string) *models.Vars_attributes_category {
 	return result
 }
 
-// NewOrganizationsVarsetsPostBody creates a new organizations.ItemVarsetsPostRequestBody
-// from parameters.
-func NewOrganizationsVarsetsPostBody(variableSetName string) *models.VarsetsEnvelope {
+// NewVarset creates a new models.VarsetsEnvelope for creating a variable set from parameters.
+func NewVarset(variableSetName string) *models.VarsetsEnvelope {
 	attrib := &models.Varsets_attributes{}
 	attrib.SetName(&variableSetName)
 
 	data := &models.Varsets{}
 	data.SetAttributes(attrib)
+
 	body := &models.VarsetsEnvelope{}
 	body.SetData(data)
 

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -47,7 +47,7 @@ func (r Resolver) VariableSet(ctx context.Context, organization, name string) (*
 
 	if r.createIfNotFound {
 		// Create the Variable Set
-		created, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Varsets().Post(ctx, NewOrganizationsVarsetsPostBody(name), nil)
+		created, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Varsets().Post(ctx, NewVarset(name), nil)
 		if err != nil {
 			return nil, fmt.Errorf("variable set named %q could not be created: %w", name, err)
 		}

--- a/internal/pkg/cmd/context.go
+++ b/internal/pkg/cmd/context.go
@@ -242,7 +242,7 @@ func (ctx *Context) applyGlobalFlags(c *Command) error {
 
 	// --jq implies --json and is only compatible with --json or --agent
 	if ctx.flags.jq != "" {
-		if f == format.Markdown {
+		if f != format.Unset && f != format.JSON && f != format.Agent {
 			return fmt.Errorf("--jq cannot be used with --markdown; only --json or --agent output is supported")
 		}
 		if f == format.Unset {

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -54,6 +54,7 @@ var excludeColumns = map[string][]string{
 // JSONAPIDisplayer prepares responses within a JSON:API data envelope to be formatted.
 type JSONAPIDisplayer struct {
 	payload      any
+	rawPayload   any
 	resourceType string
 	collection   bool
 }
@@ -69,8 +70,15 @@ func (d JSONAPIDisplayer) DefaultFormat() Format {
 	return Pretty
 }
 
-// Payload implements the Displayer interface.
+// Payload implements the Displayer interface. It returns the full JSON:API
+// envelope for use by the JSON output format.
 func (d JSONAPIDisplayer) Payload() any {
+	return d.rawPayload
+}
+
+// TemplatedPayload implements the TemplatedPayload interface. It returns the
+// flattened attribute rows for use by table and pretty output formats.
+func (d JSONAPIDisplayer) TemplatedPayload() any {
 	return d.payload
 }
 
@@ -150,6 +158,7 @@ func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 
 	return &JSONAPIDisplayer{
 		payload:      rows,
+		rawPayload:   payload,
 		resourceType: resourceType,
 		collection:   collection,
 	}, nil

--- a/internal/pkg/format/output.go
+++ b/internal/pkg/format/output.go
@@ -362,7 +362,7 @@ func (o *Outputter) outputJSON(d Displayer) error {
 
 	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshall result to JSON: %w", err)
+		return fmt.Errorf("failed to marshal result to JSON: %w", err)
 	}
 
 	fmt.Fprintln(o.io.Out(), string(data))


### PR DESCRIPTION

<img width="1098" height="630" alt="Screenshot 2026-04-29 at 06 48 24" src="https://github.com/user-attachments/assets/80f18a5e-5275-406d-8420-638d91b872a0" />

<img width="1098" height="630" alt="Screenshot 2026-04-29 at 06 48 04" src="https://github.com/user-attachments/assets/241ac790-25ad-4c77-8743-ab7d5d67f20a" />


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

