### PR TITLE
api schema get: accept exact API path to show all operations

### DIFF
--- a/internal/commands/api/schema.go
+++ b/internal/commands/api/schema.go
@@ -135,21 +135,27 @@ func (d SchemaSearchResultsDisplayer) FieldTemplates() []format.Field {
 func newCmdAPISchemaGet(ctx *cmd.Context) *cmd.Command {
 	return &cmd.Command{
 		Name:           "get",
-		ShortHelp:      "Show one API operation schema",
+		ShortHelp:      "Show API operation schema by operation ID or path",
 		NoAuthRequired: true,
 		LongHelp: heredoc.New(ctx.IO).Must(`
-		Show a trimmed OpenAPI document for a single operationId.
+		Show a trimmed OpenAPI document for a single operationId or all operations on an exact API path.
 		`),
 		Args: cmd.PositionalArguments{
 			Args: []cmd.PositionalArgument{{
-				Name:          "OPERATION_ID",
-				Documentation: "The exact OpenAPI operationId to inspect.",
+				Name:          "OPERATION_ID_OR_PATH",
+				Documentation: "An exact OpenAPI operationId or an API path (starting with /) to inspect.",
 			}},
 		},
-		Examples: []cmd.Example{{
-			Preamble: "Inspect the getWorkspace operation",
-			Command:  "$ tfcloud api schema get getWorkspace",
-		}},
+		Examples: []cmd.Example{
+			{
+				Preamble: "Inspect the getWorkspace operation",
+				Command:  "$ tfcloud api schema get getWorkspace",
+			},
+			{
+				Preamble: "Show all operations on a path",
+				Command:  "$ tfcloud api schema get /organizations/{organization}/workspaces",
+			},
+		},
 		RunF: func(_ *cmd.Command, args []string) error {
 			document, err := loadSchemaDocumentForGet(ctx)
 			if err != nil {

--- a/internal/commands/api/schema.go
+++ b/internal/commands/api/schema.go
@@ -156,12 +156,17 @@ func newCmdAPISchemaGet(ctx *cmd.Context) *cmd.Command {
 				return err
 			}
 
-			operationDocument, err := schemaOperationDocument(document, args[0])
+			var result map[string]any
+			if strings.HasPrefix(args[0], "/") {
+				result, err = schemaPathDocument(document, args[0])
+			} else {
+				result, err = schemaOperationDocument(document, args[0])
+			}
 			if err != nil {
 				return err
 			}
 
-			body, err := json.MarshalIndent(operationDocument, "", "  ")
+			body, err := json.MarshalIndent(result, "", "  ")
 			if err != nil {
 				return fmt.Errorf("marshal operation schema: %w", err)
 			}

--- a/internal/commands/api/schema_spec.go
+++ b/internal/commands/api/schema_spec.go
@@ -184,11 +184,19 @@ func schemaOperationDocument(spec map[string]any, operationID string) (map[strin
 	}
 
 	resolved := dereferenceSchemaOperation(operation, spec, map[string]bool{})
+	pathItem := map[string]any{
+		strings.ToLower(method): resolved,
+	}
+
+	if rawPathItem, ok := pathValue[path].(map[string]any); ok {
+		if params, ok := rawPathItem["parameters"]; ok {
+			pathItem["parameters"] = dereferenceOpenAPIValue(params, spec, map[string]bool{})
+		}
+	}
+
 	result := map[string]any{
 		"paths": map[string]any{
-			path: map[string]any{
-				strings.ToLower(method): resolved,
-			},
+			path: pathItem,
 		},
 	}
 	if version, ok := spec["openapi"]; ok {

--- a/internal/commands/api/schema_spec.go
+++ b/internal/commands/api/schema_spec.go
@@ -178,31 +178,25 @@ func schemaOperationDocument(spec map[string]any, operationID string) (map[strin
 		return nil, fmt.Errorf("OpenAPI spec does not contain a valid paths object")
 	}
 
-	path, method, operation, err := findSchemaOperation(pathValue, operationID)
+	path, method, _, err := findSchemaOperation(pathValue, operationID)
 	if err != nil {
 		return nil, err
 	}
 
-	resolved := dereferenceSchemaOperation(operation, spec, map[string]bool{})
-	pathItem := map[string]any{
-		strings.ToLower(method): resolved,
+	doc, err := schemaPathDocument(spec, path)
+	if err != nil {
+		return nil, err
 	}
 
-	if rawPathItem, ok := pathValue[path].(map[string]any); ok {
-		if params, ok := rawPathItem["parameters"]; ok {
-			pathItem["parameters"] = dereferenceOpenAPIValue(params, spec, map[string]bool{})
+	paths := doc["paths"].(map[string]any)
+	pathItem := paths[path].(map[string]any)
+	for key := range pathItem {
+		if isHTTPMethod(key) && strings.ToLower(key) != strings.ToLower(method) {
+			delete(pathItem, key)
 		}
 	}
 
-	result := map[string]any{
-		"paths": map[string]any{
-			path: pathItem,
-		},
-	}
-	if version, ok := spec["openapi"]; ok {
-		result["openapi"] = version
-	}
-	return result, nil
+	return doc, nil
 }
 
 func schemaPathDocument(spec map[string]any, path string) (map[string]any, error) {
@@ -213,7 +207,7 @@ func schemaPathDocument(spec map[string]any, path string) (map[string]any, error
 
 	rawPathItem, ok := pathsValue[path]
 	if !ok {
-		return nil, fmt.Errorf("path %q not found in OpenAPI spec", path)
+		return nil, fmt.Errorf("path %q not found", path)
 	}
 
 	methods, ok := rawPathItem.(map[string]any)

--- a/internal/commands/api/schema_spec.go
+++ b/internal/commands/api/schema_spec.go
@@ -197,6 +197,50 @@ func schemaOperationDocument(spec map[string]any, operationID string) (map[strin
 	return result, nil
 }
 
+func schemaPathDocument(spec map[string]any, path string) (map[string]any, error) {
+	pathsValue, ok := spec["paths"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("OpenAPI spec does not contain a valid paths object")
+	}
+
+	rawPathItem, ok := pathsValue[path]
+	if !ok {
+		return nil, fmt.Errorf("path %q not found in OpenAPI spec", path)
+	}
+
+	methods, ok := rawPathItem.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid path item for %q", path)
+	}
+
+	pathItem := make(map[string]any)
+
+	if params, ok := methods["parameters"]; ok {
+		pathItem["parameters"] = dereferenceOpenAPIValue(params, spec, map[string]bool{})
+	}
+
+	for method, rawOperation := range methods {
+		if !isHTTPMethod(method) {
+			continue
+		}
+		operation, ok := rawOperation.(map[string]any)
+		if !ok {
+			continue
+		}
+		pathItem[strings.ToLower(method)] = dereferenceSchemaOperation(operation, spec, map[string]bool{})
+	}
+
+	result := map[string]any{
+		"paths": map[string]any{
+			path: pathItem,
+		},
+	}
+	if version, ok := spec["openapi"]; ok {
+		result["openapi"] = version
+	}
+	return result, nil
+}
+
 func dereferenceSchemaOperation(operation map[string]any, root map[string]any, refsInProgress map[string]bool) map[string]any {
 	resolved := make(map[string]any, len(operation))
 	for key, value := range operation {

--- a/internal/commands/api/schema_spec.go
+++ b/internal/commands/api/schema_spec.go
@@ -191,7 +191,7 @@ func schemaOperationDocument(spec map[string]any, operationID string) (map[strin
 	paths := doc["paths"].(map[string]any)
 	pathItem := paths[path].(map[string]any)
 	for key := range pathItem {
-		if isHTTPMethod(key) && strings.ToLower(key) != strings.ToLower(method) {
+		if isHTTPMethod(key) && !strings.EqualFold(key, method) {
 			delete(pathItem, key)
 		}
 	}

--- a/internal/commands/api/schema_test.go
+++ b/internal/commands/api/schema_test.go
@@ -238,8 +238,6 @@ func TestCmdAPISchemaGetByPathNotFound(t *testing.T) {
 	r.Equal(1, command.Run([]string{"/nonexistent"}))
 }
 
-
-
 func TestLoadSchemaSpecBytesFallsBackToEmbedded(t *testing.T) {
 	t.Parallel()
 

--- a/internal/commands/api/schema_test.go
+++ b/internal/commands/api/schema_test.go
@@ -178,6 +178,68 @@ func TestCmdAPISchemaGetRun(t *testing.T) {
 	r.Empty(io.Error.String())
 }
 
+func TestCmdAPISchemaGetByPath(t *testing.T) {
+	r := require.New(t)
+
+	io := iostreams.Test()
+	originalLoader := loadSchemaDocumentForGet
+	loadSchemaDocumentForGet = func(*cmd.Context) (map[string]any, error) {
+		return map[string]any{
+			"openapi": "3.0.0",
+			"paths": map[string]any{
+				"/workspaces/{workspace_id}": map[string]any{
+					"parameters": []any{
+						map[string]any{"name": "workspace_id", "in": "path", "required": true},
+					},
+					"get": map[string]any{
+						"operationId": "getWorkspace",
+						"summary":     "Get Workspace",
+					},
+					"patch": map[string]any{
+						"operationId": "updateWorkspace",
+						"summary":     "Update a Workspace",
+					},
+				},
+			},
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadSchemaDocumentForGet = originalLoader
+	})
+
+	command := newCmdAPISchemaGet(testCommandContext(io))
+	command.SetIO(io)
+	r.Equal(0, command.Run([]string{"/workspaces/{workspace_id}"}))
+
+	output := io.Output.String()
+	r.Contains(output, `"getWorkspace"`)
+	r.Contains(output, `"updateWorkspace"`)
+	r.Contains(output, `"workspace_id"`)
+	r.Empty(io.Error.String())
+}
+
+func TestCmdAPISchemaGetByPathNotFound(t *testing.T) {
+	r := require.New(t)
+
+	io := iostreams.Test()
+	originalLoader := loadSchemaDocumentForGet
+	loadSchemaDocumentForGet = func(*cmd.Context) (map[string]any, error) {
+		return map[string]any{
+			"openapi": "3.0.0",
+			"paths":   map[string]any{},
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadSchemaDocumentForGet = originalLoader
+	})
+
+	command := newCmdAPISchemaGet(testCommandContext(io))
+	command.SetIO(io)
+	r.Equal(1, command.Run([]string{"/nonexistent"}))
+}
+
+
+
 func TestLoadSchemaSpecBytesFallsBackToEmbedded(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

### Summary
Extends `api schema get` to accept either an operation ID (existing behavior) or an exact API path. When given a path (detected by leading /), it returns the full dereferenced OpenAPI document for all operations on that path, including path-level parameters.

### Changes
1. Added `schemaPathDocument` function that looks up an exact path in the spec and returns all operations with dereferenced request bodies (responses left as $refs to keep output compact)
2. Refactored `schemaOperationDocument` to delegate to `schemaPathDocument` and filter to the matched method, so both code paths share the same logic and operation ID lookups now include path-level parameters
3. Updated help text, arg name, and examples

### Usage
All operations on a path
`tfcloud api schema get /workspaces/{workspace_id}`
Single operation by ID (unchanged)
`tfcloud api schema get getWorkspace`
Error case
`tfcloud api schema get /nonexistent`
returns `ERROR: path "/nonexistent" not found`
Example output
```
$ tfcloud api schema get /workspaces/{workspace_id}
{
  "openapi": "3.0.0",
  "paths": {
    "/workspaces/{workspace_id}": {
      "parameters": [
        { "name": "workspace_id", "in": "path", "required": true, "schema": { "type": "string" } }
      ],
      "get": { "operationId": "getWorkspace", ... },
      "patch": { "operationId": "updateWorkspace", ... },
      "delete": { "operationId": "deleteWorkspace", ... }
    }
  }
}
```

### Tests
`go test ./internal/commands/api/ -run "TestCmdAPISchemaGetByPath|TestCmdAPISchemaGetByPathNotFound|TestCmdAPISchemaGetRun|TestSchemaOperationDocumentDereferencesRefs" -v`