### PR TITLE
feat: add path parameter resolution

### DIFF
--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/tfcloud/internal/pkg/format"
 	"github.com/hashicorp/tfcloud/internal/pkg/heredoc"
 	"github.com/hashicorp/tfcloud/internal/pkg/iostreams"
+	terraformcfg "github.com/hashicorp/tfcloud/internal/pkg/terraform"
 )
 
 const (
@@ -188,6 +189,15 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 				return fmt.Errorf("failed to create API client: %w", err)
 			}
 
+			// Resolve path tokens ({workspace}, {organization}, etc.) before URL resolution.
+			if strings.Contains(path, "{") {
+				resolvedPath, resolveErr := resolvePathTokensFromContext(ctx, apiClient, path, opts.PathTokens)
+				if resolveErr != nil {
+					return resolveErr
+				}
+				path = resolvedPath
+			}
+
 			resolvedURL, err := client.ResolveURL(*apiClient.BaseURL, path)
 			if err != nil {
 				return fmt.Errorf("invalid input path/URL %q", path)
@@ -207,6 +217,38 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdAPISchema(ctx))
 
 	return cmd
+}
+
+// resolvePathTokensFromContext resolves {token} placeholders using the command context.
+// Organization and workspace are auto-resolved from profile config and terraform cloud config.
+func resolvePathTokensFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathTokens map[string]string) (string, error) {
+	// Determine organization context: explicit -p flag > profile > terraform config.
+	organization := ""
+	if v, ok := pathTokens["organization"]; ok {
+		organization = v
+	} else if v, ok := pathTokens["organization_name"]; ok {
+		organization = v
+	}
+	if organization == "" {
+		organization = ctx.Profile.Organization
+	}
+
+	// Determine workspace context from terraform config (workspace is not stored in profile).
+	var workspace string
+	cfg, cfgErr := terraformcfg.FindCloudConfig(".")
+	if cfgErr == nil {
+		if organization == "" {
+			organization = cfg.Organization
+		}
+		workspace = cfg.Workspace
+	}
+
+	resolver := client.NewResolver(apiClient, false, false)
+	return client.ResolvePathTokens(ctx.ShutdownCtx, path, client.PathTokenResolutionOpts{
+		PathTokens:   pathTokens,
+		Organization: organization,
+		Workspace:    workspace,
+	}, resolver)
 }
 
 func runAPI(opts *Opts) error {

--- a/internal/pkg/client/path_tokens.go
+++ b/internal/pkg/client/path_tokens.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// PathTokenResolutionOpts configures path token resolution.
+type PathTokenResolutionOpts struct {
+	// PathTokens are explicit token=value mappings from the -p flag.
+	PathTokens map[string]string
+	// Organization is the resolved organization context (from flag, profile, or terraform config).
+	Organization string
+	// Workspace is the resolved workspace name (from terraform config), used for auto-resolution.
+	Workspace string
+}
+
+// ResolvePathTokens resolves all {token} placeholders in a URL path to their API values.
+// Tokens that map to a known resource type are resolved using the Resolver (name→ID).
+// The organization token is substituted directly (TFC API accepts org names in paths).
+// Returns the resolved path string with all tokens replaced.
+func ResolvePathTokens(ctx context.Context, path string, opts PathTokenResolutionOpts, resolver *Resolver) (string, error) {
+	var errs []string
+	result := path
+
+	for {
+		start := strings.IndexByte(result, '{')
+		if start < 0 {
+			break
+		}
+		end := strings.IndexByte(result[start:], '}')
+		if end < 0 {
+			break
+		}
+		end += start
+
+		tokenName := result[start+1 : end]
+		value, err := resolveTokenValue(ctx, tokenName, opts, resolver)
+		if err != nil {
+			errs = append(errs, err.Error())
+			result = result[:start] + result[end+1:]
+			continue
+		}
+
+		result = result[:start] + value + result[end+1:]
+	}
+
+	if len(errs) > 0 {
+		return "", fmt.Errorf("failed to resolve path tokens:\n  %s", strings.Join(errs, "\n  "))
+	}
+
+	return result, nil
+}
+
+// resolveTokenValue determines the resolved value for a single path token.
+// It first checks for an explicit -p value, then falls back to auto-resolution from config.
+func resolveTokenValue(ctx context.Context, tokenName string, opts PathTokenResolutionOpts, resolver *Resolver) (string, error) {
+	name, explicit := opts.PathTokens[tokenName]
+
+	switch tokenName {
+	case "organization", "organization_name":
+		if explicit {
+			return name, nil
+		}
+		if opts.Organization == "" {
+			return "", fmt.Errorf("{%s}: no organization configured; use -p '%s=NAME' or set a default organization in your profile", tokenName, tokenName)
+		}
+		return opts.Organization, nil
+
+	case "workspace", "workspace_id", "workspace_name":
+		if !explicit {
+			name = opts.Workspace
+		}
+		if name == "" {
+			return "", fmt.Errorf("{%s}: no workspace configured; use -p '%s=NAME' or run in a directory with terraform cloud configuration", tokenName, tokenName)
+		}
+		if opts.Organization == "" {
+			return "", fmt.Errorf("{%s}: organization is required to resolve workspace %q", tokenName, name)
+		}
+		id, err := resolver.Workspace(ctx, opts.Organization, name)
+		if err != nil {
+			return "", fmt.Errorf("{%s}: %w", tokenName, err)
+		}
+		return *id, nil
+
+	case "team", "team_id":
+		if !explicit {
+			return "", fmt.Errorf("{%s}: use -p '%s=NAME' to specify a team", tokenName, tokenName)
+		}
+		if opts.Organization == "" {
+			return "", fmt.Errorf("{%s}: organization is required to resolve team %q", tokenName, name)
+		}
+		id, err := resolver.Team(ctx, opts.Organization, name)
+		if err != nil {
+			return "", fmt.Errorf("{%s}: %w", tokenName, err)
+		}
+		return *id, nil
+
+	case "project", "project_id":
+		if !explicit {
+			return "", fmt.Errorf("{%s}: use -p '%s=NAME' to specify a project", tokenName, tokenName)
+		}
+		if opts.Organization == "" {
+			return "", fmt.Errorf("{%s}: organization is required to resolve project %q", tokenName, name)
+		}
+		id, err := resolver.Project(ctx, opts.Organization, name)
+		if err != nil {
+			return "", fmt.Errorf("{%s}: %w", tokenName, err)
+		}
+		return *id, nil
+
+	case "varset", "varset_id":
+		if !explicit {
+			return "", fmt.Errorf("{%s}: use -p '%s=NAME' to specify a variable set", tokenName, tokenName)
+		}
+		if opts.Organization == "" {
+			return "", fmt.Errorf("{%s}: organization is required to resolve variable set %q", tokenName, name)
+		}
+		id, err := resolver.VariableSet(ctx, opts.Organization, name)
+		if err != nil {
+			return "", fmt.Errorf("{%s}: %w", tokenName, err)
+		}
+		return *id, nil
+
+	default:
+		if explicit {
+			return name, nil
+		}
+		return "", fmt.Errorf("{%s}: unrecognized path token; use -p '%s=VALUE' to provide a value", tokenName, tokenName)
+	}
+}

--- a/internal/pkg/client/path_tokens_test.go
+++ b/internal/pkg/client/path_tokens_test.go
@@ -1,0 +1,296 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePathTokens_NoTokens(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens(context.Background(), "/workspaces", PathTokenResolutionOpts{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/workspaces", result)
+}
+
+func TestResolvePathTokens_OrganizationDirectSubstitution(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens(context.Background(), "/organizations/{organization}/workspaces", PathTokenResolutionOpts{
+		Organization: "my-org",
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/organizations/my-org/workspaces", result)
+}
+
+func TestResolvePathTokens_OrganizationNameToken(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens(context.Background(), "/organizations/{organization_name}/workspaces", PathTokenResolutionOpts{
+		Organization: "my-org",
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/organizations/my-org/workspaces", result)
+}
+
+func TestResolvePathTokens_OrganizationFromExplicitFlag(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens(context.Background(), "/organizations/{organization}/teams", PathTokenResolutionOpts{
+		PathTokens:   map[string]string{"organization": "flag-org"},
+		Organization: "profile-org",
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/organizations/flag-org/teams", result)
+}
+
+func TestResolvePathTokens_OrganizationMissing(t *testing.T) {
+	t.Parallel()
+	_, err := ResolvePathTokens(context.Background(), "/organizations/{organization}/workspaces", PathTokenResolutionOpts{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no organization configured")
+}
+
+func TestResolvePathTokens_WorkspaceResolution(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/organizations/my-org/workspaces/my-ws" && r.Method == "GET" {
+			writeJSONAPI(w, map[string]any{
+				"data": map[string]any{
+					"id":   "ws-abc123",
+					"type": "workspaces",
+					"attributes": map[string]any{
+						"name": "my-ws",
+					},
+				},
+			})
+			return
+		}
+		http.Error(w, "unexpected: "+r.URL.Path, 500)
+	}))
+	defer server.Close()
+
+	apiClient, err := New(server.URL, "test-token", nil)
+	require.NoError(t, err)
+	resolver := NewResolver(apiClient, false, false)
+
+	result, err := ResolvePathTokens(context.Background(), "/workspaces/{workspace}/vars", PathTokenResolutionOpts{
+		PathTokens:   map[string]string{"workspace": "my-ws"},
+		Organization: "my-org",
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "/workspaces/ws-abc123/vars", result)
+}
+
+func TestResolvePathTokens_WorkspaceAutoResolveFromConfig(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/organizations/my-org/workspaces/config-ws" && r.Method == "GET" {
+			writeJSONAPI(w, map[string]any{
+				"data": map[string]any{
+					"id":   "ws-fromcfg",
+					"type": "workspaces",
+					"attributes": map[string]any{
+						"name": "config-ws",
+					},
+				},
+			})
+			return
+		}
+		http.Error(w, "unexpected: "+r.URL.Path, 500)
+	}))
+	defer server.Close()
+
+	apiClient, err := New(server.URL, "test-token", nil)
+	require.NoError(t, err)
+	resolver := NewResolver(apiClient, false, false)
+
+	result, err := ResolvePathTokens(context.Background(), "/workspaces/{workspace_id}/runs", PathTokenResolutionOpts{
+		Organization: "my-org",
+		Workspace:    "config-ws",
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "/workspaces/ws-fromcfg/runs", result)
+}
+
+func TestResolvePathTokens_WorkspaceMissingOrganization(t *testing.T) {
+	t.Parallel()
+	_, err := ResolvePathTokens(context.Background(), "/workspaces/{workspace}/vars", PathTokenResolutionOpts{
+		PathTokens: map[string]string{"workspace": "my-ws"},
+	}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "organization is required")
+}
+
+func TestResolvePathTokens_TeamResolution(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/organizations/my-org/teams" && r.Method == "GET" {
+			writeJSONAPI(w, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":   "team-owners123",
+						"type": "teams",
+						"attributes": map[string]any{
+							"name": "owners",
+						},
+					},
+				},
+			})
+			return
+		}
+		http.Error(w, "unexpected: "+r.URL.Path, 500)
+	}))
+	defer server.Close()
+
+	apiClient, err := New(server.URL, "test-token", nil)
+	require.NoError(t, err)
+	resolver := NewResolver(apiClient, false, false)
+
+	result, err := ResolvePathTokens(context.Background(), "/teams/{team_id}", PathTokenResolutionOpts{
+		PathTokens:   map[string]string{"team_id": "owners"},
+		Organization: "my-org",
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "/teams/team-owners123", result)
+}
+
+func TestResolvePathTokens_ProjectResolution(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/organizations/my-org/projects" && r.Method == "GET" {
+			writeJSONAPI(w, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":   "prj-def456",
+						"type": "projects",
+						"attributes": map[string]any{
+							"name": "my-project",
+						},
+					},
+				},
+			})
+			return
+		}
+		http.Error(w, "unexpected: "+r.URL.Path, 500)
+	}))
+	defer server.Close()
+
+	apiClient, err := New(server.URL, "test-token", nil)
+	require.NoError(t, err)
+	resolver := NewResolver(apiClient, false, false)
+
+	result, err := ResolvePathTokens(context.Background(), "/projects/{project_id}/varsets", PathTokenResolutionOpts{
+		PathTokens:   map[string]string{"project_id": "my-project"},
+		Organization: "my-org",
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "/projects/prj-def456/varsets", result)
+}
+
+func TestResolvePathTokens_VarsetResolution(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/organizations/my-org/varsets" && r.Method == "GET" {
+			writeJSONAPI(w, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":   "varset-ghi789",
+						"type": "varsets",
+						"attributes": map[string]any{
+							"name": "my-varset",
+						},
+					},
+				},
+			})
+			return
+		}
+		http.Error(w, "unexpected: "+r.URL.Path, 500)
+	}))
+	defer server.Close()
+
+	apiClient, err := New(server.URL, "test-token", nil)
+	require.NoError(t, err)
+	resolver := NewResolver(apiClient, false, false)
+
+	result, err := ResolvePathTokens(context.Background(), "/varsets/{varset_id}/relationships/vars", PathTokenResolutionOpts{
+		PathTokens:   map[string]string{"varset_id": "my-varset"},
+		Organization: "my-org",
+	}, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "/varsets/varset-ghi789/relationships/vars", result)
+}
+
+func TestResolvePathTokens_MultipleTokens(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/organizations/my-org/workspaces/ws-one" && r.Method == "GET" {
+			writeJSONAPI(w, map[string]any{
+				"data": map[string]any{
+					"id":   "ws-resolved1",
+					"type": "workspaces",
+					"attributes": map[string]any{
+						"name": "ws-one",
+					},
+				},
+			})
+			return
+		}
+		http.Error(w, "unexpected: "+r.URL.Path, 500)
+	}))
+	defer server.Close()
+
+	apiClient, err := New(server.URL, "test-token", nil)
+	require.NoError(t, err)
+	resolver := NewResolver(apiClient, false, false)
+
+	result, err := ResolvePathTokens(context.Background(), "/organizations/{organization_name}/workspaces/{workspace_name}", PathTokenResolutionOpts{
+		PathTokens:   map[string]string{"workspace_name": "ws-one"},
+		Organization: "my-org",
+	}, resolver)
+	require.NoError(t, err)
+	// organization_name substitutes the name directly, workspace_name resolves to ID
+	assert.Equal(t, "/organizations/my-org/workspaces/ws-resolved1", result)
+}
+
+func TestResolvePathTokens_UnknownTokenWithExplicitValue(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens(context.Background(), "/some-resource/{custom_id}/details", PathTokenResolutionOpts{
+		PathTokens: map[string]string{"custom_id": "literal-value"},
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/some-resource/literal-value/details", result)
+}
+
+func TestResolvePathTokens_UnknownTokenWithoutValue(t *testing.T) {
+	t.Parallel()
+	_, err := ResolvePathTokens(context.Background(), "/some-resource/{unknown_thing}/details", PathTokenResolutionOpts{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unrecognized path token")
+	assert.Contains(t, err.Error(), "unknown_thing")
+}
+
+func TestResolvePathTokens_StackNotRecognized(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens(context.Background(), "/stacks/{stack_id}", PathTokenResolutionOpts{
+		PathTokens:   map[string]string{"stack_id": "my-stack"},
+		Organization: "my-org",
+	}, nil)
+	// stack_id is not a recognized resource type, so explicit value passes through as-is.
+	require.NoError(t, err)
+	assert.Equal(t, "/stacks/my-stack", result)
+}
+
+func writeJSONAPI(w http.ResponseWriter, payload map[string]any) {
+	w.Header().Set("Content-Type", "application/vnd.api+json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -25,6 +25,62 @@ func NewResolver(client *Client, createIfNotFound, dryRun bool) *Resolver {
 	}
 }
 
+// Workspace resolves a workspace by organization + name to its internal ID.
+func (r Resolver) Workspace(ctx context.Context, organization, name string) (*string, error) {
+	workspace, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Workspaces().ByWorkspace_name(name).Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("workspace named %q was not found in organization %q: %w", name, organization, err)
+	}
+
+	return workspace.GetData().GetId(), nil
+}
+
+// Team resolves a team by organization + name to its internal ID.
+func (r Resolver) Team(ctx context.Context, organization, name string) (*string, error) {
+	requestConfig := &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
+		QueryParameters: &organizations.ItemTeamsRequestBuilderGetQueryParameters{
+			Filternames: &name,
+		},
+	}
+
+	items, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Teams().Get(ctx, requestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items.GetData() {
+		att := item.GetAttributes()
+		if att.GetName() != nil && *att.GetName() == name {
+			return item.GetId(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("team named %q was not found in organization %q", name, organization)
+}
+
+// Project resolves a project by organization + name to its internal ID.
+func (r Resolver) Project(ctx context.Context, organization, name string) (*string, error) {
+	requestConfig := &abstractions.RequestConfiguration[organizations.ItemProjectsRequestBuilderGetQueryParameters]{
+		QueryParameters: &organizations.ItemProjectsRequestBuilderGetQueryParameters{
+			Filternames: &name,
+		},
+	}
+
+	items, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Projects().Get(ctx, requestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items.GetData() {
+		att := item.GetAttributes()
+		if att.GetName() != nil && *att.GetName() == name {
+			return item.GetId(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("project named %q was not found in organization %q", name, organization)
+}
+
 // VariableSet resolves a variable set by organization + name.
 func (r Resolver) VariableSet(ctx context.Context, organization, name string) (*string, error) {
 	requestConfig := &abstractions.RequestConfiguration[organizations.ItemVarsetsRequestBuilderGetQueryParameters]{


### PR DESCRIPTION
This PR adds resolution of path tokens in the `api` command.

The `-p`/`--pathtoken` flag was declared but never consumed. This PR wires it up: `{workspace}`, `{team}`, `{project}`, and `{varset}` tokens in API paths are resolved from a resource name to its external ID before the request is made. `{organization}` substitutes directly, since the API accepts names.

Organization and workspace auto-resolve from profile config and local terraform cloud configuration, in that order, when not explicitly provided as flags.

`Workspace()`, `Team()`, and `Project()` methods have been added to the client Resolver.

## Usage
```
   # List runs for a workspace by name
   tfcloud api /workspaces/{workspace}/runs -p workspace=my-workspace

   # Organization auto-resolves from profile
   tfcloud api /organizations/{organization}/teams

   # Resolve a team by name
   tfcloud api /teams/{team_id} -p team_id=owners

   # Multiple tokens
   tfcloud api /varsets/{varset_id}/relationships/vars -p varset_id=my-varset

   # Unknown tokens pass through with explicit values
   tfcloud api /runs/{run_id} -p run_id=run-abc123
```

## Testing
```
   go test ./internal/pkg/client/... -run TestResolvePathTokens -v
   go test ./... -count=1
```