### PR TITLE
feat: add path parameter resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.16.0
 	github.com/posener/complete v1.2.3
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.16.3
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
@@ -74,7 +74,7 @@ require (
 	github.com/klauspost/compress v1.15.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/microsoft/kiota-http-go v1.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,11 +149,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -223,8 +222,8 @@ github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cA
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.8 h1:gMBdYMTHt2mmTdXW8YfvRjRUZ0GhyGV+IqSH9H15bGw=
 github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.8/go.mod h1:Z5KcoM0YLC7INlNhEezeIZ0TZNYf7WSNO0Lvah4DSeQ=
@@ -276,7 +275,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -77,7 +77,15 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 		Name:      "api",
 		ShortHelp: "Perform any API request",
 		LongHelp: heredoc.New(ctx.IO).Mustf(`
-		The {{ template "mdCodeOrBold" "%s api" }} command performs any API v2 request.
+		The {{ template "mdCodeOrBold" "%s api" }} command performs any HCP Terraform API v2 request.
+
+		Use {name} placeholders for path parameters and -p to set their values:
+
+		  tfcloud api /workspaces/{workspace}/runs -p workspace=my-workspace
+
+		Organization resolves automatically from the active profile or local Terraform cloud config.
+		Workspaces, teams, projects, and varsets resolve from name to external ID. Values that
+		already look like IDs (ws-, team-, prj-, varset- prefixes) are used directly.
 		`, config.Name),
 		Args: cmd.PositionalArguments{
 			// Predict paths from the OpenAPI spec for autocompletion.
@@ -85,7 +93,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 			Args: []cmd.PositionalArgument{
 				{
 					Name:          "PATH",
-					Documentation: "The API path to request, ex. /account/details. Unless -a or -i is used, the command will perform a GET request.",
+					Documentation: "API path or URL. Supports {name} path parameters resolved via -p. Organization auto-fills from profile.",
 				},
 			},
 		},
@@ -154,10 +162,10 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 					Value:        flagvalue.SimpleMap(nil, &opts.Query),
 				},
 				{
-					Name:         "pathtoken",
+					Name:         "pathparam",
 					Shorthand:    "p",
-					DisplayValue: "TOKEN=NAME",
-					Description:  "Resolve a path {token} with the given name. For example, --pathtoken 'workspace=foo' would replace {workspace} in the path with the ID of the foo workspace.",
+					DisplayValue: "KEY=VALUE",
+					Description:  "Provide a hint for path parameter resolution. The TFE API typically requires a resource ID for resource-specific requests. Use of the --pathparam flag allows automatic resolution to resource ID from name (workspaces, teams, projects, varsets). This flag can be used to specify an organization and workspace, but these resource IDs will also be automatically resolved from the active profile or local Terraform config if either is present.",
 					Repeatable:   true,
 					Value:        flagvalue.SimpleMap(nil, &opts.PathTokens),
 				},
@@ -167,6 +175,14 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 			{
 				Preamble: "List workspaces in the default organization",
 				Command:  heredoc.New(ctx.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s api /organizations/{organization}/workspaces`, config.Name),
+			},
+			{
+				Preamble: "List runs for a workspace by name (resolved to ID)",
+				Command:  heredoc.New(ctx.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Must(`$ tfcloud api /workspaces/{workspace}/runs -p workspace=my-workspace`),
+			},
+			{
+				Preamble: "Use a known ID directly (no resolution)",
+				Command:  heredoc.New(ctx.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Must(`$ tfcloud api /workspaces/{workspace}/runs -p workspace=ws-abc123`),
 			},
 			{
 				Preamble: "Create a project using attributes",
@@ -216,7 +232,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 
 			// Resolve path tokens ({workspace}, {organization}, etc.) before URL resolution.
 			if strings.Contains(path, "{") {
-				resolvedPath, resolveErr := resolvePathTokensFromContext(ctx, apiClient, path, opts.PathTokens)
+				resolvedPath, resolveErr := resolvePathParamsFromContext(ctx, apiClient, path, opts.PathTokens)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -244,12 +260,12 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 	return cmd
 }
 
-// resolvePathTokensFromContext resolves {token} placeholders using the command context.
+// resolvePathParamsFromContext resolves {token} placeholders using the command context.
 // Organization and workspace are auto-filled from profile or terraform cloud config.
 // Tokens preceded by a known resource segment (workspaces, teams, projects, varsets)
 // are resolved from name to external ID via the API.
-func resolvePathTokensFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathTokens map[string]string) (string, error) {
-	tokenSegments := client.ParsePathTokens(path)
+func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathTokens map[string]string) (string, error) {
+	tokenSegments := client.ParsePathParams(path)
 
 	// Auto-fill organization from profile or terraform config if not explicit.
 	org := ""
@@ -305,7 +321,7 @@ func resolvePathTokensFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 		pathTokens[token] = id
 	}
 
-	return client.ResolvePathTokens(path, pathTokens)
+	return client.ResolvePathParams(path, pathTokens)
 }
 
 // resolveOrg returns the organization from profile or terraform cloud config.

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/tfctl-cli/internal/pkg/heredoc"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/openapi"
+	terraformcfg "github.com/hashicorp/tfctl-cli/internal/pkg/terraform"
 )
 
 const (
@@ -213,6 +214,15 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 				return fmt.Errorf("failed to create API client: %w", err)
 			}
 
+			// Resolve path tokens ({workspace}, {organization}, etc.) before URL resolution.
+			if strings.Contains(path, "{") {
+				resolvedPath, resolveErr := resolvePathTokensFromContext(ctx, apiClient, path, opts.PathTokens)
+				if resolveErr != nil {
+					return resolveErr
+				}
+				path = resolvedPath
+			}
+
 			resolvedURL, err := client.ResolveURL(*apiClient.BaseURL, path)
 			if err != nil {
 				return fmt.Errorf("invalid input path/URL %q", path)
@@ -232,6 +242,106 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 	cmd.AddChild(NewCmdAPISchema(ctx))
 
 	return cmd
+}
+
+// resolvePathTokensFromContext resolves {token} placeholders using the command context.
+// Organization and workspace are auto-filled from profile or terraform cloud config.
+// Tokens preceded by a known resource segment (workspaces, teams, projects, varsets)
+// are resolved from name to external ID via the API.
+func resolvePathTokensFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathTokens map[string]string) (string, error) {
+	tokenSegments := client.ParsePathTokens(path)
+
+	// Auto-fill organization from profile or terraform config if not explicit.
+	org := ""
+	for token, segment := range tokenSegments {
+		if segment == "organizations" {
+			if _, ok := pathTokens[token]; !ok {
+				if org == "" {
+					org = resolveOrg(ctx)
+				}
+				if org != "" {
+					pathTokens[token] = org
+				}
+			} else {
+				org = pathTokens[token]
+			}
+		}
+	}
+	if org == "" {
+		org = resolveOrg(ctx)
+	}
+
+	// Auto-fill workspace from terraform config if not explicit.
+	for token, segment := range tokenSegments {
+		if segment == "workspaces" {
+			if _, ok := pathTokens[token]; !ok {
+				if cfg, err := terraformcfg.FindCloudConfig("."); err == nil && cfg.Workspace != "" {
+					pathTokens[token] = cfg.Workspace
+				}
+			}
+		}
+	}
+
+	// Resolve names → external IDs for tokens preceded by known resource segments.
+	resolver := client.NewResolver(apiClient, false, false)
+	for token, segment := range tokenSegments {
+		value, ok := pathTokens[token]
+		if !ok {
+			continue
+		}
+		if !client.IsResolvableSegment(segment) {
+			continue
+		}
+		if client.LooksLikeExternalID(segment, value) {
+			continue
+		}
+		if org == "" {
+			return "", fmt.Errorf("organization required to resolve %s name %q; configure a profile or use -p with an organization token", segment, value)
+		}
+		id, err := lookupResource(ctx.ShutdownCtx, resolver, segment, org, value)
+		if err != nil {
+			return "", err
+		}
+		pathTokens[token] = id
+	}
+
+	return client.ResolvePathTokens(path, pathTokens)
+}
+
+// resolveOrg returns the organization from profile or terraform cloud config.
+func resolveOrg(ctx *cmd.Context) string {
+	if ctx.Profile.Organization != "" {
+		return ctx.Profile.Organization
+	}
+	if cfg, err := terraformcfg.FindCloudConfig("."); err == nil && cfg.Organization != "" {
+		return cfg.Organization
+	}
+	return ""
+}
+
+// lookupResource resolves a resource name to its external ID via the API.
+func lookupResource(goCtx context.Context, resolver *client.Resolver, segment, org, name string) (string, error) {
+	var id *string
+	var err error
+	switch segment {
+	case "workspaces":
+		id, err = resolver.Workspace(goCtx, org, name)
+	case "teams":
+		id, err = resolver.Team(goCtx, org, name)
+	case "projects":
+		id, err = resolver.Project(goCtx, org, name)
+	case "varsets":
+		id, err = resolver.VariableSet(goCtx, org, name)
+	default:
+		return name, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if id == nil {
+		return "", fmt.Errorf("%s %q resolved to nil ID", segment, name)
+	}
+	return *id, nil
 }
 
 func runAPI(opts *Opts) error {

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -230,7 +230,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 				return fmt.Errorf("failed to create API client: %w", err)
 			}
 
-			// Resolve path tokens ({workspace}, {organization}, etc.) before URL resolution.
+			// Resolve path params ({workspace}, {organization}, etc.) before URL resolution.
 			if strings.Contains(path, "{") {
 				resolvedPath, resolveErr := resolvePathParamsFromContext(ctx, apiClient, path, opts.PathParams)
 				if resolveErr != nil {
@@ -260,29 +260,31 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 	return cmd
 }
 
-// resolvePathParamsFromContext resolves {token} placeholders using the command context.
-// Organization and workspace are auto-filled from profile or terraform cloud config.
+// resolvePathParamsFromContext resolves {param} placeholders using the command context.
 // Params preceded by a known resource segment (workspaces, teams, projects, varsets)
 // are resolved from name to external ID via the API.
 func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathParams map[string]string) (string, error) {
-	tokenSegments := client.ParsePathParams(path)
+	if pathParams == nil {
+		pathParams = make(map[string]string)
+	}
+	paramSegments := client.ParsePathParams(path)
 
 	// Load terraform cloud config once for org/workspace auto-fill.
 	cloudCfg, _ := terraformcfg.FindCloudConfig(".")
 
 	// Auto-fill organization from profile or terraform config if not explicit.
 	org := ""
-	for token, segment := range tokenSegments {
+	for param, segment := range paramSegments {
 		if segment == "organizations" {
-			if _, ok := pathParams[token]; !ok {
+			if _, ok := pathParams[param]; !ok {
 				if org == "" {
 					org = resolveOrg(ctx, cloudCfg)
 				}
 				if org != "" {
-					pathParams[token] = org
+					pathParams[param] = org
 				}
 			} else {
-				org = pathParams[token]
+				org = pathParams[param]
 			}
 		}
 	}
@@ -291,20 +293,20 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 	}
 
 	// Auto-fill workspace from terraform config if not explicit.
-	for token, segment := range tokenSegments {
+	for param, segment := range paramSegments {
 		if segment == "workspaces" {
-			if _, ok := pathParams[token]; !ok {
-				if cfg, err := terraformcfg.FindCloudConfig("."); err == nil && cfg.Workspace != "" {
-					pathParams[token] = cfg.Workspace
+			if _, ok := pathParams[param]; !ok {
+				if cloudCfg != nil && cloudCfg.Workspace != "" {
+					pathParams[param] = cloudCfg.Workspace
 				}
 			}
 		}
 	}
 
-	// Resolve names → external IDs for tokens preceded by known resource segments.
+	// Resolve names → external IDs for params preceded by known resource segments.
 	resolver := client.NewResolver(apiClient, false, false)
-	for token, segment := range tokenSegments {
-		value, ok := pathParams[token]
+	for param, segment := range paramSegments {
+		value, ok := pathParams[param]
 		if !ok {
 			continue
 		}
@@ -315,13 +317,13 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 			continue
 		}
 		if org == "" {
-			return "", fmt.Errorf("organization required to resolve %s name %q; configure a profile or use -p with an organization token", segment, value)
+			return "", fmt.Errorf("organization required to resolve %s name %q; configure a profile or use -p with an organization param", segment, value)
 		}
 		id, err := lookupResource(ctx.ShutdownCtx, resolver, segment, org, value)
 		if err != nil {
 			return "", err
 		}
-		pathParams[token] = id
+		pathParams[param] = id
 	}
 
 	return client.ResolvePathParams(path, pathParams)

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -267,13 +267,16 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathParams map[string]string) (string, error) {
 	tokenSegments := client.ParsePathParams(path)
 
+	// Load terraform cloud config once for org/workspace auto-fill.
+	cloudCfg, _ := terraformcfg.FindCloudConfig(".")
+
 	// Auto-fill organization from profile or terraform config if not explicit.
 	org := ""
 	for token, segment := range tokenSegments {
 		if segment == "organizations" {
 			if _, ok := pathParams[token]; !ok {
 				if org == "" {
-					org = resolveOrg(ctx)
+					org = resolveOrg(ctx, cloudCfg)
 				}
 				if org != "" {
 					pathParams[token] = org
@@ -284,7 +287,7 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 		}
 	}
 	if org == "" {
-		org = resolveOrg(ctx)
+		org = resolveOrg(ctx, cloudCfg)
 	}
 
 	// Auto-fill workspace from terraform config if not explicit.
@@ -325,12 +328,12 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 }
 
 // resolveOrg returns the organization from profile or terraform cloud config.
-func resolveOrg(ctx *cmd.Context) string {
+func resolveOrg(ctx *cmd.Context, cloudCfg *terraformcfg.CloudConfig) string {
 	if ctx.Profile.Organization != "" {
 		return ctx.Profile.Organization
 	}
-	if cfg, err := terraformcfg.FindCloudConfig("."); err == nil && cfg.Organization != "" {
-		return cfg.Organization
+	if cloudCfg != nil && cloudCfg.Organization != "" {
+		return cloudCfg.Organization
 	}
 	return ""
 }

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/posener/complete"
 
+	tfe "github.com/hashicorp/go-tfe"
+
 	"github.com/hashicorp/tfctl-cli/internal/config"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
@@ -84,7 +86,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 		  tfcloud api /workspaces/{workspace}/runs -p workspace=my-workspace
 
 		Organization resolves automatically from the active profile or local Terraform cloud config.
-		Workspaces, teams, projects, and varsets resolve from name to external ID. Values that
+		Workspaces, teams, projects, and varsets resolve from name to ID. Values that
 		already look like IDs (ws-, team-, prj-, varset- prefixes) are used directly.
 		`, config.Name),
 		Args: cmd.PositionalArguments{
@@ -93,7 +95,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 			Args: []cmd.PositionalArgument{
 				{
 					Name:          "PATH",
-					Documentation: "API path or URL. Supports {name} path parameters resolved via -p. Organization auto-fills from profile.",
+					Documentation: "API path or URL. Supports {name} path parameter name resolution",
 				},
 			},
 		},
@@ -173,7 +175,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 		},
 		Examples: []cmd.Example{
 			{
-				Preamble: "List workspaces in the default organization",
+				Preamble: "List workspaces in the active profile's organization",
 				Command:  heredoc.New(ctx.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s api /organizations/{organization}/workspaces`, config.Name),
 			},
 			{
@@ -262,7 +264,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 
 // resolvePathParamsFromContext resolves {param} placeholders using the command context.
 // Params preceded by a known resource segment (workspaces, teams, projects, varsets)
-// are resolved from name to external ID via the API.
+// are resolved from name to ID via the API.
 func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathParams map[string]string) (string, error) {
 	if pathParams == nil {
 		pathParams = make(map[string]string)
@@ -303,7 +305,7 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 		}
 	}
 
-	// Resolve names → external IDs for params preceded by known resource segments.
+	// Resolve names → IDs for params preceded by known resource segments.
 	resolver := client.NewResolver(apiClient, false, false)
 	for param, segment := range paramSegments {
 		value, ok := pathParams[param]
@@ -313,7 +315,7 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 		if !client.IsResolvableSegment(segment) {
 			continue
 		}
-		if client.LooksLikeExternalID(segment, value) {
+		if client.LooksLikeID(segment, value) {
 			continue
 		}
 		if org == "" {
@@ -340,23 +342,14 @@ func resolveOrg(ctx *cmd.Context, cloudCfg *terraformcfg.CloudConfig) string {
 	return ""
 }
 
-// lookupResource resolves a resource name to its external ID via the API.
+// lookupResource resolves a resource name to its ID via the API.
 func lookupResource(goCtx context.Context, resolver *client.Resolver, segment, org, name string) (string, error) {
-	var id *string
-	var err error
-	switch segment {
-	case "workspaces":
-		id, err = resolver.Workspace(goCtx, org, name)
-	case "teams":
-		id, err = resolver.Team(goCtx, org, name)
-	case "projects":
-		id, err = resolver.Project(goCtx, org, name)
-	case "varsets":
-		id, err = resolver.VariableSet(goCtx, org, name)
-	default:
-		return name, nil
-	}
+	id, err := resolver.ResolveFromName(goCtx, segment, org, name)
 	if err != nil {
+		if errors.Is(err, tfe.ErrNotFound) {
+			return "", fmt.Errorf("%s named %q not found in organization %q", segment, name, org)
+		}
+
 		return "", err
 	}
 	if id == nil {

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -50,7 +50,7 @@ type Opts struct {
 	URL          *url.URL
 	Attributes   map[string]string
 	Query        map[string]string
-	PathTokens   map[string]string
+	PathParams   map[string]string
 	InputRequest string
 	Method       string
 	ResourceType string
@@ -167,7 +167,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 					DisplayValue: "KEY=VALUE",
 					Description:  "Provide a hint for path parameter resolution. The TFE API typically requires a resource ID for resource-specific requests. Use of the --pathparam flag allows automatic resolution to resource ID from name (workspaces, teams, projects, varsets). This flag can be used to specify an organization and workspace, but these resource IDs will also be automatically resolved from the active profile or local Terraform config if either is present.",
 					Repeatable:   true,
-					Value:        flagvalue.SimpleMap(nil, &opts.PathTokens),
+					Value:        flagvalue.SimpleMap(nil, &opts.PathParams),
 				},
 			},
 		},
@@ -232,7 +232,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 
 			// Resolve path tokens ({workspace}, {organization}, etc.) before URL resolution.
 			if strings.Contains(path, "{") {
-				resolvedPath, resolveErr := resolvePathParamsFromContext(ctx, apiClient, path, opts.PathTokens)
+				resolvedPath, resolveErr := resolvePathParamsFromContext(ctx, apiClient, path, opts.PathParams)
 				if resolveErr != nil {
 					return resolveErr
 				}
@@ -262,24 +262,24 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 
 // resolvePathParamsFromContext resolves {token} placeholders using the command context.
 // Organization and workspace are auto-filled from profile or terraform cloud config.
-// Tokens preceded by a known resource segment (workspaces, teams, projects, varsets)
+// Params preceded by a known resource segment (workspaces, teams, projects, varsets)
 // are resolved from name to external ID via the API.
-func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathTokens map[string]string) (string, error) {
+func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, path string, pathParams map[string]string) (string, error) {
 	tokenSegments := client.ParsePathParams(path)
 
 	// Auto-fill organization from profile or terraform config if not explicit.
 	org := ""
 	for token, segment := range tokenSegments {
 		if segment == "organizations" {
-			if _, ok := pathTokens[token]; !ok {
+			if _, ok := pathParams[token]; !ok {
 				if org == "" {
 					org = resolveOrg(ctx)
 				}
 				if org != "" {
-					pathTokens[token] = org
+					pathParams[token] = org
 				}
 			} else {
-				org = pathTokens[token]
+				org = pathParams[token]
 			}
 		}
 	}
@@ -290,9 +290,9 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 	// Auto-fill workspace from terraform config if not explicit.
 	for token, segment := range tokenSegments {
 		if segment == "workspaces" {
-			if _, ok := pathTokens[token]; !ok {
+			if _, ok := pathParams[token]; !ok {
 				if cfg, err := terraformcfg.FindCloudConfig("."); err == nil && cfg.Workspace != "" {
-					pathTokens[token] = cfg.Workspace
+					pathParams[token] = cfg.Workspace
 				}
 			}
 		}
@@ -301,7 +301,7 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 	// Resolve names → external IDs for tokens preceded by known resource segments.
 	resolver := client.NewResolver(apiClient, false, false)
 	for token, segment := range tokenSegments {
-		value, ok := pathTokens[token]
+		value, ok := pathParams[token]
 		if !ok {
 			continue
 		}
@@ -318,10 +318,10 @@ func resolvePathParamsFromContext(ctx *cmd.Context, apiClient *client.Client, pa
 		if err != nil {
 			return "", err
 		}
-		pathTokens[token] = id
+		pathParams[token] = id
 	}
 
-	return client.ResolvePathParams(path, pathTokens)
+	return client.ResolvePathParams(path, pathParams)
 }
 
 // resolveOrg returns the organization from profile or terraform cloud config.

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -741,6 +741,33 @@ func serverURL(r *http.Request) string {
 	return scheme + "://" + r.Host
 }
 
+func TestLookupResource_ErrNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Mock server that returns 404 for workspace lookup.
+	server, _ := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/organizations/my-org/workspaces/nonexistent": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"errors": []map[string]any{
+					{"status": "404", "title": "not found"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	apiClient, err := client.New(server.URL, "test-token", http.Header{})
+	require.NoError(t, err)
+
+	resolver := client.NewResolver(apiClient, false, false)
+	_, err = lookupResource(context.Background(), resolver, "workspaces", "my-org", "nonexistent")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `workspaces named "nonexistent" not found in organization "my-org"`)
+}
+
 func TestWriteDryRunRequest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -683,7 +683,7 @@ func newTestOpts(t *testing.T, address string, io *iostreams.Testing, mutate fun
 		Headers:     []string{},
 		Attributes:  map[string]string{},
 		Query:       map[string]string{},
-		PathTokens:  map[string]string{},
+		PathParams:  map[string]string{},
 	}
 	mutate(opts)
 	return opts

--- a/internal/pkg/client/path_params.go
+++ b/internal/pkg/client/path_params.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// ResolvePathTokens replaces all {token} placeholders in a URL path with values
+// ResolvePathParams replaces all {token} placeholders in a URL path with values
 // from the tokens map. Any unresolved tokens are returned as an error.
-func ResolvePathTokens(path string, tokens map[string]string) (string, error) {
+func ResolvePathParams(path string, tokens map[string]string) (string, error) {
 	result := path
 	for k, v := range tokens {
 		result = strings.ReplaceAll(result, "{"+k+"}", v)
@@ -24,9 +24,9 @@ func ResolvePathTokens(path string, tokens map[string]string) (string, error) {
 	return result, nil
 }
 
-// ParsePathTokens returns a map of token names to their preceding path segments.
+// ParsePathParams returns a map of token names to their preceding path segments.
 // For example, "/workspaces/{workspace_id}/runs" returns {"workspace_id": "workspaces"}.
-func ParsePathTokens(path string) map[string]string {
+func ParsePathParams(path string) map[string]string {
 	result := make(map[string]string)
 	for {
 		start := strings.IndexByte(path, '{')

--- a/internal/pkg/client/path_params.go
+++ b/internal/pkg/client/path_params.go
@@ -5,26 +5,26 @@ import (
 	"strings"
 )
 
-// ResolvePathParams replaces all {token} placeholders in a URL path with values
-// from the tokens map. Any unresolved tokens are returned as an error.
-func ResolvePathParams(path string, tokens map[string]string) (string, error) {
+// ResolvePathParams replaces all {param} placeholders in a URL path with values
+// from the params map. Any unresolved params are returned as an error.
+func ResolvePathParams(path string, params map[string]string) (string, error) {
 	result := path
-	for k, v := range tokens {
+	for k, v := range params {
 		result = strings.ReplaceAll(result, "{"+k+"}", v)
 	}
 
-	// Check for unresolved tokens.
+	// Check for unresolved params.
 	if start := strings.IndexByte(result, '{'); start >= 0 {
 		if end := strings.IndexByte(result[start:], '}'); end >= 0 {
-			token := result[start+1 : start+end]
-			return "", fmt.Errorf("unresolved path token {%s}; use -p '%s=VALUE'", token, token)
+			param := result[start+1 : start+end]
+			return "", fmt.Errorf("unresolved path param {%s}; use -p '%s=VALUE'", param, param)
 		}
 	}
 
 	return result, nil
 }
 
-// ParsePathParams returns a map of token names to their preceding path segments.
+// ParsePathParams returns a map of param names to their preceding path segments.
 // For example, "/workspaces/{workspace_id}/runs" returns {"workspace_id": "workspaces"}.
 func ParsePathParams(path string) map[string]string {
 	result := make(map[string]string)

--- a/internal/pkg/client/path_params.go
+++ b/internal/pkg/client/path_params.go
@@ -68,9 +68,9 @@ func IsResolvableSegment(segment string) bool {
 	return false
 }
 
-// LooksLikeExternalID returns true if the value already appears to be an
-// external ID for the given resource segment, based on known prefixes.
-func LooksLikeExternalID(segment, value string) bool {
+// LooksLikeID returns true if the value already appears to be an
+// ID for the given resource segment, based on known prefixes.
+func LooksLikeID(segment, value string) bool {
 	switch segment {
 	case "workspaces":
 		return strings.HasPrefix(value, "ws-")

--- a/internal/pkg/client/path_params_test.go
+++ b/internal/pkg/client/path_params_test.go
@@ -14,7 +14,7 @@ func TestResolvePathParams_NoParams(t *testing.T) {
 	assert.Equal(t, "/workspaces", result)
 }
 
-func TestResolvePathParams_SingleToken(t *testing.T) {
+func TestResolvePathParams_SingleParam(t *testing.T) {
 	t.Parallel()
 	result, err := ResolvePathParams("/workspaces/{workspace_id}/runs", map[string]string{
 		"workspace_id": "ws-abc123",
@@ -33,7 +33,7 @@ func TestResolvePathParams_MultipleParams(t *testing.T) {
 	assert.Equal(t, "/organizations/my-org/workspaces/my-ws", result)
 }
 
-func TestResolvePathParams_UnresolvedToken(t *testing.T) {
+func TestResolvePathParams_UnresolvedParam(t *testing.T) {
 	t.Parallel()
 	_, err := ResolvePathParams("/workspaces/{workspace_id}/runs", map[string]string{})
 	require.Error(t, err)
@@ -57,7 +57,7 @@ func TestResolvePathParams_NoBraces(t *testing.T) {
 	assert.Equal(t, "/account/details", result)
 }
 
-func TestResolvePathParams_RepeatedToken(t *testing.T) {
+func TestResolvePathParams_RepeatedParam(t *testing.T) {
 	t.Parallel()
 	result, err := ResolvePathParams("/workspaces/{id}/varsets/{id}", map[string]string{
 		"id": "ws-123",
@@ -74,22 +74,22 @@ func TestParsePathParams(t *testing.T) {
 		expected map[string]string
 	}{
 		{
-			name:     "single token",
+			name:     "single param",
 			path:     "/workspaces/{workspace_id}/runs",
 			expected: map[string]string{"workspace_id": "workspaces"},
 		},
 		{
-			name:     "multiple tokens",
+			name:     "multiple params",
 			path:     "/organizations/{org_name}/workspaces/{workspace_id}",
 			expected: map[string]string{"org_name": "organizations", "workspace_id": "workspaces"},
 		},
 		{
-			name:     "no tokens",
+			name:     "no params",
 			path:     "/account/details",
 			expected: map[string]string{},
 		},
 		{
-			name:     "token at root",
+			name:     "param at root",
 			path:     "/{resource_id}",
 			expected: map[string]string{"resource_id": ""},
 		},

--- a/internal/pkg/client/path_params_test.go
+++ b/internal/pkg/client/path_params_test.go
@@ -7,25 +7,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolvePathTokens_NoTokens(t *testing.T) {
+func TestResolvePathParams_NoParams(t *testing.T) {
 	t.Parallel()
-	result, err := ResolvePathTokens("/workspaces", nil)
+	result, err := ResolvePathParams("/workspaces", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "/workspaces", result)
 }
 
-func TestResolvePathTokens_SingleToken(t *testing.T) {
+func TestResolvePathParams_SingleToken(t *testing.T) {
 	t.Parallel()
-	result, err := ResolvePathTokens("/workspaces/{workspace_id}/runs", map[string]string{
+	result, err := ResolvePathParams("/workspaces/{workspace_id}/runs", map[string]string{
 		"workspace_id": "ws-abc123",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "/workspaces/ws-abc123/runs", result)
 }
 
-func TestResolvePathTokens_MultipleTokens(t *testing.T) {
+func TestResolvePathParams_MultipleParams(t *testing.T) {
 	t.Parallel()
-	result, err := ResolvePathTokens("/organizations/{organization_name}/workspaces/{workspace_name}", map[string]string{
+	result, err := ResolvePathParams("/organizations/{organization_name}/workspaces/{workspace_name}", map[string]string{
 		"organization_name": "my-org",
 		"workspace_name":    "my-ws",
 	})
@@ -33,40 +33,40 @@ func TestResolvePathTokens_MultipleTokens(t *testing.T) {
 	assert.Equal(t, "/organizations/my-org/workspaces/my-ws", result)
 }
 
-func TestResolvePathTokens_UnresolvedToken(t *testing.T) {
+func TestResolvePathParams_UnresolvedToken(t *testing.T) {
 	t.Parallel()
-	_, err := ResolvePathTokens("/workspaces/{workspace_id}/runs", map[string]string{})
+	_, err := ResolvePathParams("/workspaces/{workspace_id}/runs", map[string]string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "workspace_id")
 	assert.Contains(t, err.Error(), "-p")
 }
 
-func TestResolvePathTokens_PartialResolution(t *testing.T) {
+func TestResolvePathParams_PartialResolution(t *testing.T) {
 	t.Parallel()
-	_, err := ResolvePathTokens("/organizations/{org}/workspaces/{ws}", map[string]string{
+	_, err := ResolvePathParams("/organizations/{org}/workspaces/{ws}", map[string]string{
 		"org": "my-org",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ws")
 }
 
-func TestResolvePathTokens_NoBraces(t *testing.T) {
+func TestResolvePathParams_NoBraces(t *testing.T) {
 	t.Parallel()
-	result, err := ResolvePathTokens("/account/details", map[string]string{"foo": "bar"})
+	result, err := ResolvePathParams("/account/details", map[string]string{"foo": "bar"})
 	require.NoError(t, err)
 	assert.Equal(t, "/account/details", result)
 }
 
-func TestResolvePathTokens_RepeatedToken(t *testing.T) {
+func TestResolvePathParams_RepeatedToken(t *testing.T) {
 	t.Parallel()
-	result, err := ResolvePathTokens("/workspaces/{id}/varsets/{id}", map[string]string{
+	result, err := ResolvePathParams("/workspaces/{id}/varsets/{id}", map[string]string{
 		"id": "ws-123",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "/workspaces/ws-123/varsets/ws-123", result)
 }
 
-func TestParsePathTokens(t *testing.T) {
+func TestParsePathParams(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
@@ -102,7 +102,7 @@ func TestParsePathTokens(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			result := ParsePathTokens(tc.path)
+			result := ParsePathParams(tc.path)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/internal/pkg/client/path_params_test.go
+++ b/internal/pkg/client/path_params_test.go
@@ -119,16 +119,16 @@ func TestIsResolvableSegment(t *testing.T) {
 	assert.False(t, IsResolvableSegment(""))
 }
 
-func TestLooksLikeExternalID(t *testing.T) {
+func TestLooksLikeID(t *testing.T) {
 	t.Parallel()
-	assert.True(t, LooksLikeExternalID("workspaces", "ws-abc123"))
-	assert.True(t, LooksLikeExternalID("teams", "team-abc123"))
-	assert.True(t, LooksLikeExternalID("projects", "prj-abc123"))
-	assert.True(t, LooksLikeExternalID("varsets", "varset-abc123"))
+	assert.True(t, LooksLikeID("workspaces", "ws-abc123"))
+	assert.True(t, LooksLikeID("teams", "team-abc123"))
+	assert.True(t, LooksLikeID("projects", "prj-abc123"))
+	assert.True(t, LooksLikeID("varsets", "varset-abc123"))
 
-	assert.False(t, LooksLikeExternalID("workspaces", "my-workspace"))
-	assert.False(t, LooksLikeExternalID("teams", "owners"))
-	assert.False(t, LooksLikeExternalID("projects", "default"))
-	assert.False(t, LooksLikeExternalID("varsets", "my-varset"))
-	assert.False(t, LooksLikeExternalID("runs", "run-abc123"))
+	assert.False(t, LooksLikeID("workspaces", "my-workspace"))
+	assert.False(t, LooksLikeID("teams", "owners"))
+	assert.False(t, LooksLikeID("projects", "default"))
+	assert.False(t, LooksLikeID("varsets", "my-varset"))
+	assert.False(t, LooksLikeID("runs", "run-abc123"))
 }

--- a/internal/pkg/client/path_tokens.go
+++ b/internal/pkg/client/path_tokens.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResolvePathTokens replaces all {token} placeholders in a URL path with values
+// from the tokens map. Any unresolved tokens are returned as an error.
+func ResolvePathTokens(path string, tokens map[string]string) (string, error) {
+	result := path
+	for k, v := range tokens {
+		result = strings.ReplaceAll(result, "{"+k+"}", v)
+	}
+
+	// Check for unresolved tokens.
+	if start := strings.IndexByte(result, '{'); start >= 0 {
+		if end := strings.IndexByte(result[start:], '}'); end >= 0 {
+			token := result[start+1 : start+end]
+			return "", fmt.Errorf("unresolved path token {%s}; use -p '%s=VALUE'", token, token)
+		}
+	}
+
+	return result, nil
+}
+
+// ParsePathTokens returns a map of token names to their preceding path segments.
+// For example, "/workspaces/{workspace_id}/runs" returns {"workspace_id": "workspaces"}.
+func ParsePathTokens(path string) map[string]string {
+	result := make(map[string]string)
+	for {
+		start := strings.IndexByte(path, '{')
+		if start < 0 {
+			break
+		}
+		end := strings.IndexByte(path[start:], '}')
+		if end < 0 {
+			break
+		}
+		token := path[start+1 : start+end]
+
+		// Extract the segment before /{token}.
+		segment := ""
+		if start > 1 {
+			sub := path[:start]
+			if sub[len(sub)-1] == '/' {
+				sub = sub[:len(sub)-1]
+			}
+			if i := strings.LastIndexByte(sub, '/'); i >= 0 {
+				segment = sub[i+1:]
+			} else {
+				segment = sub
+			}
+		}
+		result[token] = segment
+		path = path[start+end+1:]
+	}
+	return result
+}
+
+// IsResolvableSegment returns true if the segment is a resource type that
+// supports name-to-ID resolution via the API.
+func IsResolvableSegment(segment string) bool {
+	switch segment {
+	case "workspaces", "teams", "projects", "varsets":
+		return true
+	}
+	return false
+}
+
+// LooksLikeExternalID returns true if the value already appears to be an
+// external ID for the given resource segment, based on known prefixes.
+func LooksLikeExternalID(segment, value string) bool {
+	switch segment {
+	case "workspaces":
+		return strings.HasPrefix(value, "ws-")
+	case "teams":
+		return strings.HasPrefix(value, "team-")
+	case "projects":
+		return strings.HasPrefix(value, "prj-")
+	case "varsets":
+		return strings.HasPrefix(value, "varset-")
+	}
+	return false
+}

--- a/internal/pkg/client/path_tokens_test.go
+++ b/internal/pkg/client/path_tokens_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePathTokens_NoTokens(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens("/workspaces", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/workspaces", result)
+}
+
+func TestResolvePathTokens_SingleToken(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens("/workspaces/{workspace_id}/runs", map[string]string{
+		"workspace_id": "ws-abc123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/workspaces/ws-abc123/runs", result)
+}
+
+func TestResolvePathTokens_MultipleTokens(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens("/organizations/{organization_name}/workspaces/{workspace_name}", map[string]string{
+		"organization_name": "my-org",
+		"workspace_name":    "my-ws",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/organizations/my-org/workspaces/my-ws", result)
+}
+
+func TestResolvePathTokens_UnresolvedToken(t *testing.T) {
+	t.Parallel()
+	_, err := ResolvePathTokens("/workspaces/{workspace_id}/runs", map[string]string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace_id")
+	assert.Contains(t, err.Error(), "-p")
+}
+
+func TestResolvePathTokens_PartialResolution(t *testing.T) {
+	t.Parallel()
+	_, err := ResolvePathTokens("/organizations/{org}/workspaces/{ws}", map[string]string{
+		"org": "my-org",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ws")
+}
+
+func TestResolvePathTokens_NoBraces(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens("/account/details", map[string]string{"foo": "bar"})
+	require.NoError(t, err)
+	assert.Equal(t, "/account/details", result)
+}
+
+func TestResolvePathTokens_RepeatedToken(t *testing.T) {
+	t.Parallel()
+	result, err := ResolvePathTokens("/workspaces/{id}/varsets/{id}", map[string]string{
+		"id": "ws-123",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/workspaces/ws-123/varsets/ws-123", result)
+}
+
+func TestParsePathTokens(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		path     string
+		expected map[string]string
+	}{
+		{
+			name:     "single token",
+			path:     "/workspaces/{workspace_id}/runs",
+			expected: map[string]string{"workspace_id": "workspaces"},
+		},
+		{
+			name:     "multiple tokens",
+			path:     "/organizations/{org_name}/workspaces/{workspace_id}",
+			expected: map[string]string{"org_name": "organizations", "workspace_id": "workspaces"},
+		},
+		{
+			name:     "no tokens",
+			path:     "/account/details",
+			expected: map[string]string{},
+		},
+		{
+			name:     "token at root",
+			path:     "/{resource_id}",
+			expected: map[string]string{"resource_id": ""},
+		},
+		{
+			name:     "nested path",
+			path:     "/varsets/{varset_id}/relationships/vars",
+			expected: map[string]string{"varset_id": "varsets"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := ParsePathTokens(tc.path)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsResolvableSegment(t *testing.T) {
+	t.Parallel()
+	assert.True(t, IsResolvableSegment("workspaces"))
+	assert.True(t, IsResolvableSegment("teams"))
+	assert.True(t, IsResolvableSegment("projects"))
+	assert.True(t, IsResolvableSegment("varsets"))
+	assert.False(t, IsResolvableSegment("runs"))
+	assert.False(t, IsResolvableSegment("organizations"))
+	assert.False(t, IsResolvableSegment(""))
+}
+
+func TestLooksLikeExternalID(t *testing.T) {
+	t.Parallel()
+	assert.True(t, LooksLikeExternalID("workspaces", "ws-abc123"))
+	assert.True(t, LooksLikeExternalID("teams", "team-abc123"))
+	assert.True(t, LooksLikeExternalID("projects", "prj-abc123"))
+	assert.True(t, LooksLikeExternalID("varsets", "varset-abc123"))
+
+	assert.False(t, LooksLikeExternalID("workspaces", "my-workspace"))
+	assert.False(t, LooksLikeExternalID("teams", "owners"))
+	assert.False(t, LooksLikeExternalID("projects", "default"))
+	assert.False(t, LooksLikeExternalID("varsets", "my-varset"))
+	assert.False(t, LooksLikeExternalID("runs", "run-abc123"))
+}

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -99,6 +99,22 @@ func extractCurrentRunID(rel models.RunsIdable, wsRef string) (string, error) {
 	return "", fmt.Errorf("no current run for workspace %s", wsRef)
 }
 
+// ResolveFromName resolves a resource ID from a name, based on the resource type. If the resource type is not recognized, the name is returned as-is.
+func (r Resolver) ResolveFromName(goCtx context.Context, resourceType, org, name string) (*string, error) {
+	switch resourceType {
+	case "workspaces":
+		return r.Workspace(goCtx, org, name)
+	case "teams":
+		return r.Team(goCtx, org, name)
+	case "projects":
+		return r.Project(goCtx, org, name)
+	case "varsets":
+		return r.VariableSet(goCtx, org, name)
+	default:
+		return &name, nil
+	}
+}
+
 // Workspace resolves a workspace by organization + name.
 func (r Resolver) Workspace(ctx context.Context, organization, name string) (*string, error) {
 	ws, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Workspaces().ByWorkspace_name(name).Get(ctx, nil)

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -98,3 +98,56 @@ func extractCurrentRunID(rel models.RunsIdable, wsRef string) (string, error) {
 	}
 	return "", fmt.Errorf("no current run for workspace %s", wsRef)
 }
+
+// Workspace resolves a workspace by organization + name.
+func (r Resolver) Workspace(ctx context.Context, organization, name string) (*string, error) {
+	ws, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Workspaces().ByWorkspace_name(name).Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("workspace %q not found in organization %q: %w", name, organization, err)
+	}
+	return ws.GetData().GetId(), nil
+}
+
+// Team resolves a team by organization + name.
+func (r Resolver) Team(ctx context.Context, organization, name string) (*string, error) {
+	requestConfig := &abstractions.RequestConfiguration[organizations.ItemTeamsRequestBuilderGetQueryParameters]{
+		QueryParameters: &organizations.ItemTeamsRequestBuilderGetQueryParameters{
+			Filternames: &name,
+		},
+	}
+
+	items, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Teams().Get(ctx, requestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items.GetData() {
+		if *item.GetAttributes().GetName() == name {
+			return item.GetId(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("team %q not found in organization %q", name, organization)
+}
+
+// Project resolves a project by organization + name.
+func (r Resolver) Project(ctx context.Context, organization, name string) (*string, error) {
+	requestConfig := &abstractions.RequestConfiguration[organizations.ItemProjectsRequestBuilderGetQueryParameters]{
+		QueryParameters: &organizations.ItemProjectsRequestBuilderGetQueryParameters{
+			Filternames: &name,
+		},
+	}
+
+	items, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Projects().Get(ctx, requestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range items.GetData() {
+		if *item.GetAttributes().GetName() == name {
+			return item.GetId(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("project %q not found in organization %q", name, organization)
+}

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -122,7 +122,8 @@ func (r Resolver) Team(ctx context.Context, organization, name string) (*string,
 	}
 
 	for _, item := range items.GetData() {
-		if *item.GetAttributes().GetName() == name {
+		att := item.GetAttributes()
+		if att.GetName() != nil && *att.GetName() == name {
 			return item.GetId(), nil
 		}
 	}
@@ -144,7 +145,8 @@ func (r Resolver) Project(ctx context.Context, organization, name string) (*stri
 	}
 
 	for _, item := range items.GetData() {
-		if *item.GetAttributes().GetName() == name {
+		att := item.GetAttributes()
+		if att.GetName() != nil && *att.GetName() == name {
 			return item.GetId(), nil
 		}
 	}

--- a/internal/pkg/cmd/command.go
+++ b/internal/pkg/cmd/command.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/posener/complete"
 	flag "github.com/spf13/pflag"
 

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -61,6 +61,9 @@ func (t *Table) String() string {
 	// Determine the maximum column width by subtracting from the total line LineLength
 	// the width of column separators and then dividing by the number of columns.
 	numHeaders := len(t.rows[0].cells)
+	if numHeaders == 0 {
+		return ""
+	}
 	headerSpacing := uint((numHeaders - 1)) * t.SeparatorSpaces
 	t.maxColWidth = (t.LineLength - headerSpacing) / uint(numHeaders)
 


### PR DESCRIPTION
This PR adds resolution of path parameters for the `api` command.

The `-p/--pathtoken` flag was previously declared but never consumed. This PR wires it up: `{param}`-style placeholders in API paths are resolved to their external IDs before the request is made.

Resolution strategy is determined by the path segment preceding the parameter placeholder:

 - `workspaces` → resolve workspace name to external ID via by-name endpoint
 - `teams` → resolve team name to external ID via filter[names]
 - `projects` → resolve project name to external ID via filter[names]
 - `varsets` → resolve varset name to external ID via q search + exact match
 - `organizations` → literal substitution (API accepts names directly)
 - anything else → literal substitution

For an ergonomic quick win, values that already look like external IDs (`ws-`, `team-`, `prj-`, `varset-` prefixes) skip resolution and substitute directly. This could easily be removed to increase simplicity.

Organization and workspace auto-resolve from profile config and local terraform cloud configuration when not explicitly provided via `-p`.

`Workspace()`, `Team()`, and `Project()` methods have been added to the client Resolver.

### Usage
```  
 # Fetch workspace by name (resolved to ID automatically, param name is arbitrary)
 ./bin/tfcloud api /workspaces/{workspace_name} -p workspace_name=my-workspace
 ./bin/tfcloud api /workspaces/{workspace} -p workspace=my-workspace

 # Fetch workspace by external ID — skips resolution, substitutes directly
 ./bin/tfcloud api /workspaces/{workspace_id} -p workspace_id=ws-abc123

 # Organization auto-resolves from profile
 ./bin/tfcloud api /organizations/{organization_name}/teams

 # Resolve a team by name
 ./bin/tfcloud api /teams/{team_id} -p team_id=owners

 # Varset resolution
 ./bin/tfcloud api /varsets/{varset_id}/relationships/vars -p varset_id=my-varset

 # Un-resolveable segments pass through literally
 ./bin/tfcloud api /runs/{run_id} -p run_id=run-abc123
```

### Testing
```
 go test ./internal/pkg/client/... -run "TestResolvePathTokens|TestParsePathTokens|TestIsResolvable|TestLooksLike" -v
 go test ./... -count=1
```