### PR TITLE
Fix --jq raw output and --paginate response meta

### DIFF
--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -118,7 +118,7 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 				},
 				{
 					Name:          "paginate",
-					Description:   fmt.Sprintf("Automatically paginate through results and stream them, one resource at a time, up to %d records. Only applies to successful responses with JSON:API document bodies.", MaxPaginateRecords),
+					Description:   fmt.Sprintf("Automatically paginate through all pages and return them as a single response with up to %d records. Only applies to successful responses with JSON:API document bodies.", MaxPaginateRecords),
 					Value:         flagvalue.Simple(false, &opts.Paginate),
 					IsBooleanFlag: true,
 				},
@@ -521,6 +521,9 @@ func mergePaginatedBody(body []byte, combined []any) ([]byte, error) {
 	if meta, ok := payload["meta"].(map[string]any); ok {
 		if pagination, ok := meta["pagination"].(map[string]any); ok {
 			pagination["total-count"] = len(combined)
+			pagination["page-size"] = len(combined)
+			pagination["current-page"] = 1
+			pagination["total-pages"] = 1
 		}
 	}
 	if links, ok := payload["links"].(map[string]any); ok {

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -524,6 +524,7 @@ func mergePaginatedBody(body []byte, combined []any) ([]byte, error) {
 			pagination["page-size"] = len(combined)
 			pagination["current-page"] = 1
 			pagination["total-pages"] = 1
+			pagination["prev-page"] = nil
 		}
 	}
 	if links, ok := payload["links"].(map[string]any); ok {

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -276,6 +276,39 @@ func TestRunAPI_Paginate(t *testing.T) {
 	require.Contains(t, io.Output.String(), "beta")
 }
 
+func TestMergePaginatedBody_UpdatesMeta(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"data": [{"id": "ws-2", "type": "workspaces"}],
+		"meta": {"pagination": {"current-page": 2, "page-size": 1, "total-count": 2, "total-pages": 2}},
+		"links": {"next": "https://example.com/next"}
+	}`)
+	combined := []any{
+		map[string]any{"id": "ws-1", "type": "workspaces"},
+		map[string]any{"id": "ws-2", "type": "workspaces"},
+	}
+
+	merged, err := mergePaginatedBody(body, combined)
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(merged, &result))
+
+	data := result["data"].([]any)
+	require.Len(t, data, 2)
+
+	meta := result["meta"].(map[string]any)
+	pagination := meta["pagination"].(map[string]any)
+	require.EqualValues(t, 2, pagination["total-count"])
+	require.EqualValues(t, 2, pagination["page-size"])
+	require.EqualValues(t, 1, pagination["current-page"])
+	require.EqualValues(t, 1, pagination["total-pages"])
+
+	links := result["links"].(map[string]any)
+	require.Nil(t, links["next"])
+}
+
 func TestRunAPI_DebugLogsRequestAndResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/format/json_test.go
+++ b/internal/pkg/format/json_test.go
@@ -133,7 +133,7 @@ func TestJSON_JQFilter_Field(t *testing.T) {
 	}
 
 	r.NoError(out.Display(d))
-	r.Equal("\"Hello\"\n", io.Output.String())
+	r.Equal("Hello\n", io.Output.String())
 }
 
 func TestJSON_JQFilter_Array(t *testing.T) {
@@ -153,7 +153,7 @@ func TestJSON_JQFilter_Array(t *testing.T) {
 	}
 
 	r.NoError(out.Display(d))
-	r.Equal("\"First\"\n\"Second\"\n", io.Output.String())
+	r.Equal("First\nSecond\n", io.Output.String())
 }
 
 func TestJSON_JQFilter_InvalidExpression(t *testing.T) {

--- a/internal/pkg/format/output.go
+++ b/internal/pkg/format/output.go
@@ -402,11 +402,16 @@ func (o *Outputter) outputJSONWithJQ(payload any) error {
 			return fmt.Errorf("jq filter error: %w", err)
 		}
 
-		data, err := json.MarshalIndent(v, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal jq result: %w", err)
+		switch val := v.(type) {
+		case string:
+			fmt.Fprintln(o.io.Out(), val)
+		default:
+			data, err := json.MarshalIndent(val, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal jq result: %w", err)
+			}
+			fmt.Fprintln(o.io.Out(), string(data))
 		}
-		fmt.Fprintln(o.io.Out(), string(data))
 	}
 
 	return nil


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

### Summary
- --jq now renders scalar string results without JSON quotes (matching jq -r behavior by default)
- --paginate updates all pagination meta fields (page-size, current-page, total-pages) so the merged response looks like a single page containing all records