### PR TITLE
api: page parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ tfcloud api /organizations/acme/projects -input my-project.json
 # ...or use stdin as the request body
 ./generate_hcptf_run.sh | tfcloud api /runs -input -
 
-# If using parameters in a GET request, set the method to GET.
-# This example fetches all pages of data (up to 1000 items) and sorts by created-at descending
-tfcloud api /organizations/acme/workspaces -paginate -method GET -f "sort=-created-at"
+# This example fetches all pages of data (up to 1000 items) and sorts by latest runs
+tfcloud api /organizations/acme/workspaces --all -f "sort=-current-run.created-at"
 ```
 
 #### Shell Completion

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -52,7 +52,9 @@ type Opts struct {
 	InputRequest string
 	Method       string
 	ResourceType string
-	Paginate     bool
+	All          bool
+	PageSize     int
+	PageNumber   int
 }
 
 // NewCmdAPI creates the `tfcloud api` command.
@@ -116,11 +118,22 @@ func NewCmdAPI(ctx *cmd.Context) *cmd.Command {
 					Description:  "Resource type for --attribute JSON:API request bodies. This value is inferred from the path whenever possible.",
 					Value:        flagvalue.Simple("", &opts.ResourceType),
 				},
+
 				{
-					Name:          "paginate",
-					Description:   fmt.Sprintf("Automatically paginate through all pages and return them as a single response with up to %d records. Only applies to successful responses with JSON:API document bodies.", MaxPaginateRecords),
-					Value:         flagvalue.Simple(false, &opts.Paginate),
+					Name:          "all",
+					Description:   fmt.Sprintf("Fetch all records. May be slow for large amounts of data. Limited to %d records.", MaxPaginateRecords),
+					Value:         flagvalue.Simple(false, &opts.All),
 					IsBooleanFlag: true,
+				},
+				{
+					Name:        "page-size",
+					Description: "Limit the number of records to return. Default varies by resource. Ignored if --all is set.",
+					Value:       flagvalue.Simple(0, &opts.PageSize), // page size is determined by the server, so we don't set it by default
+				},
+				{
+					Name:        "page-number",
+					Description: "Page number to return. Ignored if --all is set. Default is 1.",
+					Value:       flagvalue.Simple(1, &opts.PageNumber),
 				},
 				{
 					Name:         "attribute",
@@ -226,6 +239,24 @@ func runAPI(opts *Opts) error {
 	for key, value := range opts.Query {
 		query.Set(key, value)
 	}
+
+	// Handle pagination parameters unless --all is set.
+	if opts.PageNumber > 1 {
+		if opts.All {
+			fmt.Fprintf(opts.IO.Err(), "%s ignoring --page-number because --all is set\n", opts.IO.ColorScheme().WarningLabel())
+		} else {
+			query.Set("page[number]", fmt.Sprintf("%d", opts.PageNumber))
+		}
+	}
+
+	if opts.PageSize > 0 {
+		if opts.All {
+			fmt.Fprintf(opts.IO.Err(), "%s ignoring --page-size because --all is set\n", opts.IO.ColorScheme().WarningLabel())
+		} else {
+			query.Set("page[size]", fmt.Sprintf("%d", opts.PageSize))
+		}
+	}
+
 	opts.URL.RawQuery = query.Encode()
 
 	// Construct a request
@@ -293,7 +324,7 @@ func runAPI(opts *Opts) error {
 		verbose = true
 	}
 
-	if opts.Paginate && response.StatusCode >= 200 && response.StatusCode < 300 {
+	if opts.All && response.StatusCode >= 200 && response.StatusCode < 300 {
 		response, err = paginateResponse(opts.ShutdownCtx, opts.Client, response, requestHeaders, verbose, opts.IO.Err())
 		if err != nil {
 			return err

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (
@@ -209,7 +212,7 @@ func TestRunAPI_ExplicitMethodHeadersAndQuery(t *testing.T) {
 	t.Parallel()
 
 	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
-		"PATCH /api/v2/workspaces/ws-1": func(w http.ResponseWriter, r *http.Request) {
+		"PATCH /api/v2/workspaces/ws-1?include=organization": func(w http.ResponseWriter, r *http.Request) {
 			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
 				"data": map[string]any{
 					"id":         "ws-1",
@@ -225,7 +228,7 @@ func TestRunAPI_ExplicitMethodHeadersAndQuery(t *testing.T) {
 	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
 		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-1")
 		opts.Method = http.MethodPatch
-		opts.Query = map[string]string{"include": "organization", "page[number]": "2"}
+		opts.Query = map[string]string{"include": "organization"}
 		opts.Headers = []string{"X-Test: yes", "Accept: application/custom+json"}
 		opts.InputRequest = `{"data":{"type":"workspaces","attributes":{"name":"beta"}}}`
 	}))
@@ -236,7 +239,6 @@ func TestRunAPI_ExplicitMethodHeadersAndQuery(t *testing.T) {
 	require.Equal(t, "yes", req.Headers.Get("X-Test"))
 	require.Equal(t, "application/custom+json", req.Headers.Get("Accept"))
 	require.Equal(t, "organization", req.Query.Get("include"))
-	require.Equal(t, "2", req.Query.Get("page[number]"))
 }
 
 func TestRunAPI_Paginate(t *testing.T) {
@@ -267,13 +269,67 @@ func TestRunAPI_Paginate(t *testing.T) {
 	io := iostreams.Test()
 	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
 		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
-		opts.Paginate = true
+		opts.All = true
 	}))
 	require.NoError(t, err)
 
 	require.Len(t, recorder.All(), 2)
 	require.Contains(t, io.Output.String(), "alpha")
 	require.Contains(t, io.Output.String(), "beta")
+}
+
+func TestRunAPI_PageNumber(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces?page%5Bnumber%5D=2": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{"id": "ws-2", "type": "workspaces", "attributes": map[string]any{"name": "beta"}},
+				},
+				"links": map[string]any{"next": nil},
+				"meta":  map[string]any{"pagination": map[string]any{"total-count": 2}},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+		opts.PageNumber = 2
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, recorder.All(), 1)
+	require.Contains(t, io.Output.String(), "beta")
+}
+
+func TestRunAPI_PageSize(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces?page%5Bsize%5D=1": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{"id": "ws-1", "type": "workspaces", "attributes": map[string]any{"name": "alpha"}},
+				},
+				"links": map[string]any{"next": "/api/v2/workspaces?page[size]=1&page[number]=2"},
+				"meta":  map[string]any{"pagination": map[string]any{"total-count": 2}},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+		opts.PageSize = 1
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, recorder.All(), 1)
+	require.Contains(t, io.Output.String(), "alpha")
 }
 
 func TestMergePaginatedBody_UpdatesMeta(t *testing.T) {
@@ -516,7 +572,7 @@ func TestRunAPI_PaginateReturnsErrorResponseFromLaterPage(t *testing.T) {
 	io := iostreams.Test()
 	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
 		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
-		opts.Paginate = true
+		opts.All = true
 	}))
 	assert.ErrorIs(t, err, tfe.ErrTooManyRequests)
 	var apiErr *tfe.APIError
@@ -596,10 +652,6 @@ func newAPITestServer(routes map[string]http.HandlerFunc) (*httptest.Server, *re
 		})
 
 		if h, ok := routes[routeKey(r)]; ok {
-			h(w, r)
-			return
-		}
-		if h, ok := routes[fmt.Sprintf("%s %s", r.Method, r.URL.Path)]; ok {
 			h(w, r)
 			return
 		}

--- a/internal/commands/api/schema.go
+++ b/internal/commands/api/schema.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/internal/commands/api/schema_eval_test.go
+++ b/internal/commands/api/schema_eval_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/internal/commands/api/schema_search.go
+++ b/internal/commands/api/schema_search.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/internal/commands/api/schema_search_bluge.go
+++ b/internal/commands/api/schema_search_bluge.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/internal/commands/api/schema_search_helpers.go
+++ b/internal/commands/api/schema_search_helpers.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/internal/commands/api/schema_test.go
+++ b/internal/commands/api/schema_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package api
 
 import (

--- a/internal/commands/variable/target.go
+++ b/internal/commands/variable/target.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package variable
 
 import (

--- a/internal/commands/variable/variable_import_test.go
+++ b/internal/commands/variable/variable_import_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package variable
 
 import (

--- a/internal/pkg/client/helpers.go
+++ b/internal/pkg/client/helpers.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package client
 
 import (

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package client
 
 import (

--- a/internal/pkg/cmd/context_test.go
+++ b/internal/pkg/cmd/context_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package cmd
 
 import (

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package format
 
 import (

--- a/internal/pkg/table/markdown_test.go
+++ b/internal/pkg/table/markdown_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package table
 
 import (

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package skills contains the embedded skill definitions for tfcloud.
+package skills
+
+import "embed"
+
+// FS is the embedded filesystem containing the skill definitions for tfcloud.
+//
+//go:embed tfcloud
+var FS embed.FS

--- a/skills/tfcloud/SKILL.md
+++ b/skills/tfcloud/SKILL.md
@@ -26,12 +26,13 @@ Full CLI coverage for the entire HCP Terraform API.
 | Goal                     | Flag            | Format                                                                                     |
 |--------------------------|-----------------|--------------------------------------------------------------------------------------------|
 | Filter/extract JSON data | `--jq '<expr>'` | Built-in jq filter (no external jq needed). Implies `--json`; filter runs on the envelope. |
-| Full JSON output         | `--json`        | JSON envelope: `{ok, data, summary, breadcrumbs, meta}`                                    |
+| Full JSON output         | `--json`        | JSON envelope: `{data, relationships, meta}`                                               |
 | Show results to a user   | `--markdown`    | GFM tables, structured Markdown                                                            |
+| Audit mutations          | `--dry-run`     | No changes, only a description of what would be modified rendered to stderr.               |
 
-Always pass `--json` or `--md` explicitly — auto-detection depends on config and may not produce the format you expect. Use `--md` when composing reports, summarizing data, or displaying results inline. `--agent` is for headless integration scripts.
+Always pass `--json` or `--markdown` explicitly — auto-detection depends on config and may not produce the format you expect. Use `--markdown` when composing reports, summarizing data, or displaying results inline. `--agent` is for headless integration scripts.
 
-**Other modes:** `--quiet` (no output), `--debug` (verbose/debug logging enabled), `--jq '<expr>'` (built-in jq filter — see below), `--dry-run` (no modifications, only a description of what is modified rendered to stderr)
+**Other modes:** `--quiet` (no output), `--debug` (verbose/debug logging enabled), `--jq '<expr>'` (built-in jq filter — see below),
 
 ### CLI Introspection
 
@@ -66,6 +67,13 @@ Most related resources, such as the current run of a workspace, can be followed 
 
 **URL patterns:**
 - All resource collections are typically nested one resource deep. For example, `/organizations/{name}/workspaces` and `/workspaces/{id}/vars`.
+
+**Pagination:**
+When fetching lists of resources using the `api` command, the API returns paginated results. By default, only the first page of results is returned. You can use the following flags to control pagination:
+
+- Use `--all` to fetch all pages of results (up to 1000 items). By default, only the first page is returned.
+- Use `--page-size` to limit the number of items returned (default varies by resource).
+- Use `--page-number` to specify the page number to fetch (default is 1).
 
 ## Decision Trees
 

--- a/skills/tfcloud/SKILL.md
+++ b/skills/tfcloud/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: tfcloud
+description: |
+  Interact with HCP Terraform using the tfcloud CLI. Full API coverage. Use for ANY HCP Terraform
+  or Terraform Cloud question or action.
+license: MPL-2.0
+---
+
+# tfcloud - HCP Terraform (Terraform Cloud) Workflow CLI
+
+Full CLI coverage for the entire HCP Terraform API.
+
+## Agent Invariants
+
+**MUST follow these rules:**
+
+1. **Choose the right output mode** — `--jq` when you need to filter/extract data; `--json` for full JSON; `--markdown` when presenting results to a human (see Output Modes below). **Never pipe to external `jq` — use `--jq` instead.**
+2. **Check context** using `tfcloud profile display` before assuming configuration
+3. **API Discovery** The API is too large to document every resource. You can perform a search using `tfcloud api schema search <keyword>` to find relevant operations. When you are ready to make an API request, get the full request schema in OpenAPI format using `tfcloud api schema get <operationId>`
+4. **No Delete Operations** using the `tfcloud api` command. All delete methods must be confimed interactively. Always prompt a human to perform delete operations themselves.
+
+### Output Modes
+
+**Choosing a mode:**
+
+| Goal                     | Flag            | Format                                                                                     |
+|--------------------------|-----------------|--------------------------------------------------------------------------------------------|
+| Filter/extract JSON data | `--jq '<expr>'` | Built-in jq filter (no external jq needed). Implies `--json`; filter runs on the envelope. |
+| Full JSON output         | `--json`        | JSON envelope: `{ok, data, summary, breadcrumbs, meta}`                                    |
+| Show results to a user   | `--markdown`    | GFM tables, structured Markdown                                                            |
+
+Always pass `--json` or `--md` explicitly — auto-detection depends on config and may not produce the format you expect. Use `--md` when composing reports, summarizing data, or displaying results inline. `--agent` is for headless integration scripts.
+
+**Other modes:** `--quiet` (no output), `--debug` (verbose/debug logging enabled), `--jq '<expr>'` (built-in jq filter — see below), `--dry-run` (no modifications, only a description of what is modified rendered to stderr)
+
+### CLI Introspection
+
+Navigate unfamiliar commands with `--help`
+
+```bash
+tfcloud api --help
+```
+
+Walk the tree: start at `tfcloud --help` for top-level commands, then drill into any subcommand. Commands include `EXAMPLES` with real invocation examples.
+
+### Smart Defaults
+
+- Some commands require an `--organization` argument, but it can be omitted if there is a profile default.
+- Some commands require a `--workspace` argument, but it can be omitted if there is a terraform cloud block in the CWD.
+
+## Quick Reference
+
+| Task                  | Command                                                                   |
+|-----------------------|---------------------------------------------------------------------------|
+| Find an API operation | `tfcloud api schema search <keyword> --json`                              |
+| Get API schema        | `tfcloud api schema get <operation>`                                      |
+| List projects         | `tfcloud api /organizations/{organization}/projects --json`               |
+| Get Workspace state   | `tfcloud api /organizations/{organization}/workspaces/{workspace} --json` |
+
+
+## API Conventions
+
+The API follows a JSON:API standard convention, which all resources appearing within a JSON:API resource envelope with a `type` attribute.
+
+Most related resources, such as the current run of a workspace, can be followed by consulting the `relationships/<key>` property of the resource envelope.
+
+**URL patterns:**
+- All resource collections are typically nested one resource deep. For example, `/organizations/{name}/workspaces` and `/workspaces/{id}/vars`.
+
+## Decision Trees
+
+### Finding Content
+
+```
+Need to find something?
+├── Don't know the resource ID? → find by name using a list operation with a filter parameter
+├── Workspace run logs? → Get the current-run ID from the workspace and `tfcloud api /runs/{id} --jq '.data.attributes.["log-read-url"]'`
+└── All else fail? → tfcloud api schema search "query" --json
+```
+
+### Modifying Content
+
+```
+Want to change something?
+├── Need PATCH schema? → `tfcloud api schema get <operation>`
+└── Have ID? → `tfcloud /path/to/{id} -X PATCH -i'{ ...request body... }'`
+```
+
+## Common Workflows
+
+### TO BE DOCUMENTED
+
+## Common Errors and Debugging
+
+**Rate limiting (429):** The CLI handles backoff automatically. If you see 429 errors (exit code 5), reduce request frequency.
+
+**Missing argument errors (exit 1):**
+When a required positional argument is missing, the CLI returns a structured error naming
+the specific argument. Use this for elicitation:
+
+```bash
+$ tfcloud <command> --help
+```
+
+**Not found/Authorization errors (exit 2):**
+For security reasons, unauthorized access errors look identical to resource not found errors.
+Verify you are signed in as the expected account.
+
+```bash
+tfcloud api /account/details                      # Verify auth working
+tfcloud profile display                           # Check current configuration
+```
+
+**Authentication errors (exit 3):**
+This could indicate a token misconfiguration.
+
+```bash
+tfcloud api /account/details                      # Verify auth working
+tfcloud profile display                           # Check current configuration
+```
+
+**Network errors (exit 4):**
+This could indicate a temporary network condition or a hostname misconfiguration.
+
+```bash
+tfcloud profile display                           # Check current hostname configuration
+```
+
+**API errors (exit 5):**
+This could indicate a bug in the platform API or an inability to process the command in a timely
+manner. Try again or try a workaround.
+
+## Built-in jq Filtering
+
+The CLI has a built-in `--jq` flag powered by gojq — no external `jq` binary required. **Always prefer `--jq` over piping to external `jq`.**
+
+```bash
+# Extract fields from data array and filter by attribute
+tfcloud api /organizations/{organization}/workspaces --jq '.data[] | select(.attributes.["terraform-version"] != "1.15.1") | .relationships.["current-run"].data.id'
+
+# Access envelope metadata
+tfcloud api /organizations/{organization}/projects --jq '.meta.pagination.["total-count"]'
+```
+
+`--jq` implies `--json` — no need to pass both. String results print as plain text; objects and arrays print as formatted JSON.
+
+## Exit Codes
+
+| Exit | Meaning                          | Solution                    |
+|------|----------------------------------|-----------------------------|
+| 0    | OK                               | &mdash;                     |
+| 1    | Usage error                      | Read `tfcloud <cmd> --help` |
+| 2    | Not Found or Authorization Error | Verify URL/ID               |
+| 3    | Authentication Error             | `tfcloud auth login`        |
+| 4    | Network error                    | Check connectivity          |
+| 5    | API Server Error Persists        | Try again later             |
+| 130  | Canceled (ctrl-c).               | &mdash;                     |
+
+## Learn More
+
+- API overview: https://developer.hashicorp.com/terraform/cloud-docs/api-docs


### PR DESCRIPTION
API flags changes:
- `--page-number` and `--page-size` are now supported
- `--paginate` is now `--all` to avoid confusion

Adds/embeds `skills/tfcloud/SKILL.md` as a starting point for agent context

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
