### PR TITLE
Render source location and code snippet in run diagnostics

### DIFF
--- a/internal/commands/run/run_status.go
+++ b/internal/commands/run/run_status.go
@@ -180,6 +180,22 @@ func (d *summaryDisplayer) formatDiagnosticsPretty() string {
 		body.WriteString(cs.String(fmt.Sprintf("%s: ", label)).Color(color).Bold().String())
 		body.WriteString(cs.String(diag.Summary).Bold().String())
 		body.WriteString("\n")
+
+		if diag.Range != nil {
+			body.WriteString("\n")
+			loc := fmt.Sprintf("  on %s line %d", diag.Range.Filename, diag.Range.Start.Line)
+			if diag.Snippet != nil && diag.Snippet.Context != nil {
+				loc += fmt.Sprintf(", in %s", *diag.Snippet.Context)
+			}
+			loc += ":"
+			body.WriteString(loc)
+			body.WriteString("\n")
+		}
+
+		if diag.Snippet != nil {
+			body.WriteString(formatSnippet(cs, diag.Snippet))
+		}
+
 		if diag.Detail != "" {
 			body.WriteString("\n")
 			for _, line := range strings.Split(diag.Detail, "\n") {
@@ -218,9 +234,57 @@ func (d *summaryDisplayer) formatDiagnosticsMarkdown() string {
 			label = "Warning"
 		}
 		fmt.Fprintf(&out, "**%s: %s**\n", label, diag.Summary)
+		if diag.Range != nil {
+			loc := fmt.Sprintf("on %s line %d", diag.Range.Filename, diag.Range.Start.Line)
+			if diag.Snippet != nil && diag.Snippet.Context != nil {
+				loc += fmt.Sprintf(", in %s", *diag.Snippet.Context)
+			}
+			fmt.Fprintf(&out, "\n%s:\n", loc)
+		}
+		if diag.Snippet != nil {
+			fmt.Fprintf(&out, "\n```hcl\n%s\n```\n", diag.Snippet.Code)
+		}
 		if diag.Detail != "" {
 			fmt.Fprintf(&out, "\n%s\n", diag.Detail)
 		}
 	}
 	return out.String()
+}
+
+// formatSnippet renders a code snippet with ANSI underline highlighting,
+// matching Terraform's diagnostic output style.
+func formatSnippet(cs *iostreams.ColorScheme, snippet *client.DiagnosticSnippet) string {
+	var out strings.Builder
+
+	code := snippet.Code
+	start := clamp(snippet.HighlightStartOffset, 0, len(code))
+	end := clamp(snippet.HighlightEndOffset, start, len(code))
+
+	// Apply underline to the highlighted range.
+	var rendered string
+	if end > start {
+		before := code[:start]
+		highlight := code[start:end]
+		after := code[end:]
+		rendered = before + cs.String(highlight).Underline().String() + after
+	} else {
+		rendered = code
+	}
+
+	lines := strings.Split(rendered, "\n")
+	for i, line := range lines {
+		fmt.Fprintf(&out, "  %4d: %s\n", snippet.StartLine+i, line)
+	}
+
+	return out.String()
+}
+
+func clamp(val, min, max int) int {
+	if val < min {
+		return min
+	}
+	if val > max {
+		return max
+	}
+	return val
 }

--- a/internal/commands/run/run_status.go
+++ b/internal/commands/run/run_status.go
@@ -5,6 +5,7 @@ package run
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/mitchellh/go-wordwrap"
@@ -144,10 +145,15 @@ func (d *summaryDisplayer) StringPayload(f format.Format) string {
 		return d.formatDiagnostics(f)
 	}
 	if d.summary.RawLog != "" {
+		if f == format.Markdown {
+			return stripANSI(d.summary.RawLog)
+		}
 		return d.summary.RawLog
 	}
 	return d.summary.Message
 }
+
+var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 func (d *summaryDisplayer) formatDiagnostics(f format.Format) string {
 	switch f {
@@ -287,4 +293,8 @@ func clamp(val, min, max int) int {
 		return max
 	}
 	return val
+}
+
+func stripANSI(s string) string {
+	return ansiEscapeRe.ReplaceAllString(s, "")
 }

--- a/internal/commands/run/run_status.go
+++ b/internal/commands/run/run_status.go
@@ -285,12 +285,12 @@ func formatSnippet(cs *iostreams.ColorScheme, snippet *client.DiagnosticSnippet)
 	return out.String()
 }
 
-func clamp(val, min, max int) int {
-	if val < min {
-		return min
+func clamp(val, lo, hi int) int {
+	if val < lo {
+		return lo
 	}
-	if val > max {
-		return max
+	if val > hi {
+		return hi
 	}
 	return val
 }

--- a/internal/commands/run/run_status_test.go
+++ b/internal/commands/run/run_status_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
 )
 
 func testAPI(t *testing.T, handler http.Handler) *client.Client {
@@ -209,6 +211,7 @@ func TestRunOrCurrentRun(t *testing.T) {
 	t.Run("workspaces type by ID", func(t *testing.T) {
 		t.Parallel()
 		c := testAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/v2/workspaces/ws-123", r.URL.Path, "should use workspace ID endpoint")
 			jsonapi(w, map[string]any{
 				"data": map[string]any{
 					"id": "ws-123", "type": "workspaces",
@@ -227,9 +230,32 @@ func TestRunOrCurrentRun(t *testing.T) {
 		assert.Equal(t, "run-current", runID)
 	})
 
+	t.Run("workspaces type by ID with org set", func(t *testing.T) {
+		t.Parallel()
+		c := testAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/v2/workspaces/ws-abc", r.URL.Path, "ws- prefix should bypass org-based name lookup")
+			jsonapi(w, map[string]any{
+				"data": map[string]any{
+					"id": "ws-abc", "type": "workspaces",
+					"relationships": map[string]any{
+						"current-run": map[string]any{
+							"data": map[string]any{"id": "run-from-id", "type": "runs"},
+						},
+					},
+				},
+			})
+		}))
+
+		resolver := client.NewResolver(c, false, false)
+		runID, err := resolver.RunOrCurrentRun(context.Background(), "my-org", "workspaces", "ws-abc")
+		require.NoError(t, err)
+		assert.Equal(t, "run-from-id", runID)
+	})
+
 	t.Run("workspaces type by name", func(t *testing.T) {
 		t.Parallel()
 		c := testAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/v2/organizations/my-org/workspaces/my-ws", r.URL.Path, "should use org+name endpoint")
 			jsonapi(w, map[string]any{
 				"data": map[string]any{
 					"id": "ws-resolved", "type": "workspaces",
@@ -277,3 +303,162 @@ func TestRunOrCurrentRun(t *testing.T) {
 		assert.Contains(t, err.Error(), "unsupported resource type")
 	})
 }
+
+func TestFormatDiagnosticsPretty_WithSnippet(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	ctx := strPtr("output \"bad\"")
+	summary := &client.RunSummary{
+		Diagnostics: []client.Diagnostic{
+			{
+				Severity: "error",
+				Summary:  "Reference to undeclared input variable",
+				Detail:   "An input variable with the name \"does_not_exist\" has not been declared.",
+				Range: &client.DiagnosticRange{
+					Filename: "main.tf",
+					Start:    client.SourceLocation{Line: 2, Column: 11, Byte: 25},
+					End:      client.SourceLocation{Line: 2, Column: 31, Byte: 45},
+				},
+				Snippet: &client.DiagnosticSnippet{
+					Context:              ctx,
+					Code:                 "  value = var.does_not_exist.foo",
+					StartLine:            2,
+					HighlightStartOffset: 10,
+					HighlightEndOffset:   30,
+				},
+			},
+		},
+	}
+
+	d := &summaryDisplayer{summary: summary, io: io}
+	result := d.StringPayload(format.Pretty)
+
+	assert.Contains(t, result, "Error:")
+	assert.Contains(t, result, "Reference to undeclared input variable")
+	assert.Contains(t, result, "on main.tf line 2, in output \"bad\":")
+	assert.Contains(t, result, "   2:")
+	assert.Contains(t, result, "value = var.does_not_exist.foo")
+	assert.Contains(t, result, "╷")
+	assert.Contains(t, result, "│")
+	assert.Contains(t, result, "╵")
+}
+
+func TestFormatDiagnosticsMarkdown_WithSnippet(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	ctx := strPtr("output \"bad\"")
+	summary := &client.RunSummary{
+		Diagnostics: []client.Diagnostic{
+			{
+				Severity: "error",
+				Summary:  "Reference to undeclared input variable",
+				Detail:   "An input variable with the name \"does_not_exist\" has not been declared.",
+				Range: &client.DiagnosticRange{
+					Filename: "main.tf",
+					Start:    client.SourceLocation{Line: 2, Column: 11, Byte: 25},
+				},
+				Snippet: &client.DiagnosticSnippet{
+					Context:   ctx,
+					Code:      "  value = var.does_not_exist.foo",
+					StartLine: 2,
+				},
+			},
+		},
+	}
+
+	d := &summaryDisplayer{summary: summary, io: io}
+	result := d.StringPayload(format.Markdown)
+
+	assert.Contains(t, result, "**Error: Reference to undeclared input variable**")
+	assert.Contains(t, result, "on main.tf line 2, in output \"bad\":")
+	assert.Contains(t, result, "```hcl")
+	assert.Contains(t, result, "value = var.does_not_exist.foo")
+	assert.Contains(t, result, "```")
+	assert.NotContains(t, result, "╷")
+	assert.NotContains(t, result, "│")
+}
+
+func TestStringPayload_MarkdownStripsANSI(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	summary := &client.RunSummary{
+		Status: "errored",
+		RawLog: "Terraform v1.13.5\n\x1b[1m\x1b[31m╷\x1b[0m\n\x1b[1m\x1b[31m│\x1b[0m \x1b[1mError: Unsupported version\x1b[0m\n\x1b[1m\x1b[31m╵\x1b[0m\n",
+	}
+
+	d := &summaryDisplayer{summary: summary, io: io}
+	result := d.StringPayload(format.Markdown)
+
+	assert.NotContains(t, result, "\x1b[")
+	assert.Contains(t, result, "╷")
+	assert.Contains(t, result, "Error: Unsupported version")
+	assert.Contains(t, result, "╵")
+}
+
+func TestStringPayload_PrettyPreservesANSI(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	summary := &client.RunSummary{
+		Status: "errored",
+		RawLog: "Terraform v1.13.5\n\x1b[31mError\x1b[0m\n",
+	}
+
+	d := &summaryDisplayer{summary: summary, io: io}
+	result := d.StringPayload(format.Pretty)
+
+	assert.Contains(t, result, "\x1b[31m")
+}
+
+func TestFormatDiagnosticsPretty_RangeWithoutSnippet(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	summary := &client.RunSummary{
+		Diagnostics: []client.Diagnostic{
+			{
+				Severity: "error",
+				Summary:  "Some error",
+				Range: &client.DiagnosticRange{
+					Filename: "main.tf",
+					Start:    client.SourceLocation{Line: 5},
+				},
+			},
+		},
+	}
+
+	d := &summaryDisplayer{summary: summary, io: io}
+	result := d.StringPayload(format.Pretty)
+
+	assert.Contains(t, result, "on main.tf line 5:")
+	assert.NotContains(t, result, "in ")
+}
+
+func TestFormatDiagnosticsPretty_SnippetNoHighlight(t *testing.T) {
+	t.Parallel()
+
+	io := iostreams.Test()
+	summary := &client.RunSummary{
+		Diagnostics: []client.Diagnostic{
+			{
+				Severity: "error",
+				Summary:  "Some error",
+				Snippet: &client.DiagnosticSnippet{
+					Code:      "resource \"aws_instance\" \"web\" {}",
+					StartLine: 1,
+				},
+			},
+		},
+	}
+
+	d := &summaryDisplayer{summary: summary, io: io}
+	result := d.StringPayload(format.Pretty)
+
+	assert.Contains(t, result, "   1:")
+	assert.Contains(t, result, "resource \"aws_instance\" \"web\" {}")
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/pkg/client/resolver.go
+++ b/internal/pkg/client/resolver.go
@@ -6,6 +6,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-tfe/api/models"
 	"github.com/hashicorp/go-tfe/api/organizations"
@@ -77,7 +78,7 @@ func (r Resolver) RunOrCurrentRun(ctx context.Context, organization, resourceTyp
 }
 
 func (r Resolver) currentRunForWorkspace(ctx context.Context, organization, id string) (string, error) {
-	if organization != "" {
+	if organization != "" && !strings.HasPrefix(id, "ws-") {
 		ws, err := r.client.TFE.API.Organizations().ByOrganization_name(organization).Workspaces().ByWorkspace_name(id).Get(ctx, nil)
 		if err != nil {
 			return "", fmt.Errorf("resolving workspace %q: %w", id, err)

--- a/internal/pkg/client/run_summary.go
+++ b/internal/pkg/client/run_summary.go
@@ -27,10 +27,35 @@ type RunSummary struct {
 
 // Diagnostic represents a Terraform diagnostic message.
 type Diagnostic struct {
-	Severity string `json:"severity"`
-	Summary  string `json:"summary"`
-	Detail   string `json:"detail"`
-	Address  string `json:"address,omitempty"`
+	Severity string             `json:"severity"`
+	Summary  string             `json:"summary"`
+	Detail   string             `json:"detail"`
+	Address  string             `json:"address,omitempty"`
+	Range    *DiagnosticRange   `json:"range,omitempty"`
+	Snippet  *DiagnosticSnippet `json:"snippet,omitempty"`
+}
+
+// DiagnosticRange represents the source location of a diagnostic.
+type DiagnosticRange struct {
+	Filename string         `json:"filename"`
+	Start    SourceLocation `json:"start"`
+	End      SourceLocation `json:"end"`
+}
+
+// SourceLocation represents a position in a source file.
+type SourceLocation struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+	Byte   int `json:"byte"`
+}
+
+// DiagnosticSnippet contains the source code context for a diagnostic.
+type DiagnosticSnippet struct {
+	Context              *string `json:"context"`
+	Code                 string  `json:"code"`
+	StartLine            int     `json:"start_line"`
+	HighlightStartOffset int     `json:"highlight_start_offset"`
+	HighlightEndOffset   int     `json:"highlight_end_offset"`
 }
 
 type jsonLog struct {

--- a/internal/pkg/client/run_summary_test.go
+++ b/internal/pkg/client/run_summary_test.go
@@ -86,6 +86,27 @@ func TestParseDiagnostics_RealHCPTerraformLog(t *testing.T) {
 	if diags[0].Detail != `A managed resource "random_string" "example" has not been declared in the root module.` {
 		t.Errorf("unexpected detail: %q", diags[0].Detail)
 	}
+	if diags[0].Range == nil {
+		t.Fatal("expected range to be parsed")
+	}
+	if diags[0].Range.Filename != "main.tf" {
+		t.Errorf("expected filename 'main.tf', got %q", diags[0].Range.Filename)
+	}
+	if diags[0].Range.Start.Line != 73 {
+		t.Errorf("expected start line 73, got %d", diags[0].Range.Start.Line)
+	}
+	if diags[0].Snippet == nil {
+		t.Fatal("expected snippet to be parsed")
+	}
+	if diags[0].Snippet.Code != "  value = random_string.example.result" {
+		t.Errorf("unexpected snippet code: %q", diags[0].Snippet.Code)
+	}
+	if diags[0].Snippet.StartLine != 73 {
+		t.Errorf("expected snippet start line 73, got %d", diags[0].Snippet.StartLine)
+	}
+	if diags[0].Snippet.HighlightStartOffset != 10 || diags[0].Snippet.HighlightEndOffset != 31 {
+		t.Errorf("unexpected highlight offsets: %d-%d", diags[0].Snippet.HighlightStartOffset, diags[0].Snippet.HighlightEndOffset)
+	}
 }
 
 func TestParseDiagnostics_RealConsoleLog(t *testing.T) {


### PR DESCRIPTION
### Summary
- Add `Range` and `Snippet` fields to `Diagnostic`
- Render source location and code snippet in pretty output matching how Terraform does it
- Render source location and fenced HCL code block in markdown output
- Fix `--markdown` outputting ANSI escape codes when diagnostics come from console-mode logs
- Fix workspace ID being incorrectly resolved as a workspace name when a default organization is set

### Usage
When HCP Terraform structured logs include range and snippet data on diagnostics, we now render them the same way terraform does:
<img width="1635" height="193" alt="Screenshot 2026-05-08 at 2 26 57 PM" src="https://github.com/user-attachments/assets/26bf9854-cc86-49e3-9eed-943450888286" />

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
