### PR TITLE
fix: allow passing sparse fieldsets to api cmd

### DIFF
--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -241,6 +241,66 @@ func TestRunAPI_ExplicitMethodHeadersAndQuery(t *testing.T) {
 	require.Equal(t, "organization", req.Query.Get("include"))
 }
 
+func TestRunAPI_InlineQueryParamsSparseFieldsets(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/organizations/my-org/workspaces?fields%5Bworkspaces%5D=name": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":         "ws-1",
+						"type":       "workspaces",
+						"attributes": map[string]any{"name": "alpha"},
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/organizations/my-org/workspaces?fields[workspaces]=name")
+	}))
+	require.NoError(t, err)
+
+	req := recorder.Last()
+	require.Equal(t, "GET", req.Method)
+	require.Equal(t, "/api/v2/organizations/my-org/workspaces", req.Path)
+	require.Equal(t, "name", req.Query.Get("fields[workspaces]"))
+}
+
+func TestRunAPI_InlineQueryParamsMergedWithFlags(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces?fields%5Bworkspaces%5D=name&include=organization": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":         "ws-1",
+						"type":       "workspaces",
+						"attributes": map[string]any{"name": "alpha"},
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces?fields[workspaces]=name")
+		opts.Query = map[string]string{"include": "organization"}
+	}))
+	require.NoError(t, err)
+
+	req := recorder.Last()
+	require.Equal(t, "name", req.Query.Get("fields[workspaces]"))
+	require.Equal(t, "organization", req.Query.Get("include"))
+}
+
 func TestRunAPI_Paginate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -134,6 +134,7 @@ func (c *Client) RawRequest(ctx context.Context, req *Request) (*Response, error
 }
 
 // ResolveURL resolves an absolute or base-relative API path against base.
+// Query parameters and fragments in path are preserved.
 func ResolveURL(base url.URL, path string) (*url.URL, error) {
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
 		return url.Parse(path)
@@ -143,10 +144,15 @@ func ResolveURL(base url.URL, path string) (*url.URL, error) {
 		path = "/" + path
 	}
 
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
 	resolved := base
-	resolved.Path = strings.TrimRight(base.Path, "/") + path
-	resolved.RawQuery = ""
-	resolved.Fragment = ""
+	resolved.Path = strings.TrimRight(base.Path, "/") + parsed.Path
+	resolved.RawQuery = parsed.RawQuery
+	resolved.Fragment = parsed.Fragment
 
 	return &resolved, nil
 }

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -150,9 +150,17 @@ func ResolveURL(base url.URL, path string) (*url.URL, error) {
 	}
 
 	resolved := base
-	resolved.Path = strings.TrimRight(base.Path, "/") + parsed.Path
+	basePath := strings.TrimRight(base.Path, "/")
+	resolved.Path = basePath + parsed.Path
+	resolved.RawPath = "" // clear any base RawPath; re-set below if needed
 	resolved.RawQuery = parsed.RawQuery
 	resolved.Fragment = parsed.Fragment
+
+	// Preserve RawPath so percent-encoded separators (e.g. %2F) are not
+	// decoded into literal slashes, which would alter the path hierarchy.
+	if parsed.RawPath != "" {
+		resolved.RawPath = basePath + parsed.RawPath
+	}
 
 	return &resolved, nil
 }

--- a/internal/pkg/client/client_test.go
+++ b/internal/pkg/client/client_test.go
@@ -1,0 +1,85 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveURL(t *testing.T) {
+	t.Parallel()
+
+	base := url.URL{
+		Scheme: "https",
+		Host:   "app.terraform.io",
+		Path:   "/api/v2",
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		wantPath string
+		wantRaw  string
+	}{
+		{
+			name:     "simple path",
+			path:     "/workspaces",
+			wantPath: "/api/v2/workspaces",
+			wantRaw:  "",
+		},
+		{
+			name:     "path without leading slash",
+			path:     "workspaces",
+			wantPath: "/api/v2/workspaces",
+			wantRaw:  "",
+		},
+		{
+			name:     "sparse fieldsets",
+			path:     "/organizations/my-org/workspaces?fields[workspaces]=name",
+			wantPath: "/api/v2/organizations/my-org/workspaces",
+			wantRaw:  "fields%5Bworkspaces%5D=name",
+		},
+		{
+			name:     "multiple query params",
+			path:     "/workspaces?include=organization&fields[workspaces]=name,vcs-repo",
+			wantPath: "/api/v2/workspaces",
+			wantRaw:  "fields%5Bworkspaces%5D=name%2Cvcs-repo&include=organization",
+		},
+		{
+			name:     "pagination query params",
+			path:     "/workspaces?page[number]=2&page[size]=50",
+			wantPath: "/api/v2/workspaces",
+			wantRaw:  "page%5Bnumber%5D=2&page%5Bsize%5D=50",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveURL(base, tt.path)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPath, got.Path)
+			require.Equal(t, tt.wantRaw, got.Query().Encode())
+		})
+	}
+}
+
+func TestResolveURL_AbsoluteURL(t *testing.T) {
+	t.Parallel()
+
+	base := url.URL{
+		Scheme: "https",
+		Host:   "app.terraform.io",
+		Path:   "/api/v2",
+	}
+
+	got, err := ResolveURL(base, "https://other.host/api/v2/workspaces?fields[workspaces]=name")
+	require.NoError(t, err)
+	require.Equal(t, "other.host", got.Host)
+	require.Equal(t, "/api/v2/workspaces", got.Path)
+	require.Equal(t, "fields%5Bworkspaces%5D=name", got.Query().Encode())
+}

--- a/internal/pkg/client/client_test.go
+++ b/internal/pkg/client/client_test.go
@@ -20,10 +20,11 @@ func TestResolveURL(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		path     string
-		wantPath string
-		wantRaw  string
+		name        string
+		path        string
+		wantPath    string
+		wantRawPath string
+		wantRaw     string
 	}{
 		{
 			name:     "simple path",
@@ -55,6 +56,13 @@ func TestResolveURL(t *testing.T) {
 			wantPath: "/api/v2/workspaces",
 			wantRaw:  "page%5Bnumber%5D=2&page%5Bsize%5D=50",
 		},
+		{
+			name:        "percent-encoded path segment",
+			path:        "/workspaces/my%2Fworkspace/runs",
+			wantPath:    "/api/v2/workspaces/my/workspace/runs",
+			wantRawPath: "/api/v2/workspaces/my%2Fworkspace/runs",
+			wantRaw:     "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -63,6 +71,7 @@ func TestResolveURL(t *testing.T) {
 			got, err := ResolveURL(base, tt.path)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantPath, got.Path)
+			require.Equal(t, tt.wantRawPath, got.RawPath)
 			require.Equal(t, tt.wantRaw, got.Query().Encode())
 		})
 	}


### PR DESCRIPTION
This PR fixes sparse fieldsets when passed to the `api` command in the URL query string.

### Testing
```
# Happy path: single sparse field
tfctl api '/organizations/{organization}/workspaces?fields[workspaces]=name'

# Happy path: multiple sparse fields
tfctl api '/organizations/{organization}/workspaces?fields[workspaces]=name,description'

# Happy path: sparse field via -f flag
tfctl api /organizations/{organization}/workspaces -f 'fields[workspaces]=name'

# Happy path: different resource type
tfctl api '/organizations/{organization}/workspaces?fields[workspaces]=name,execution_mode,locked'

# Happy path: single resource (pretty format, not table)
tfctl api '/workspaces/{workspace}?fields[workspaces]=name' -p workspace=simple

# Happy path: JSON output (sparse fields don't affect --json)
tfctl api '/organizations/{organization}/workspaces?fields[workspaces]=name' --json

# Happy path: percent-encoded path segment
tfctl api '/organizations/{organization}/workspaces?fields[workspaces]=name%2Cdescription'

# Error path: nonexistent field (response should show only id & type)
tfctl api '/organizations/{organization}/workspaces?fields[workspaces]=bogus'

# Error path: no matching resource type (response should show default columns)
tfctl api '/organizations/{organization}/workspaces?fields[runs]=status'
```