### PR TITLE
feat: add auth status cmd

### DIFF
--- a/internal/commands/auth/auth.go
+++ b/internal/commands/auth/auth.go
@@ -22,5 +22,6 @@ func NewCmdAuth(ctx *cmd.Context) *cmd.Command {
 	}
 
 	cmd.AddChild(NewCmdLogin(ctx))
+	cmd.AddChild(NewCmdStatus(ctx))
 	return cmd
 }

--- a/internal/commands/auth/status.go
+++ b/internal/commands/auth/status.go
@@ -44,6 +44,13 @@ func NewCmdStatus(ctx *cmd.Context) *cmd.Command {
 		},
 		NoAuthRequired: true,
 		RunF: func(_ *cmd.Command, _ []string) error {
+			if ctx.Profile.Token != "" {
+				apiClient, err := ctx.NewAPIClient()
+				if err != nil {
+					return fmt.Errorf("failed to create API client: %w", err)
+				}
+				opts.APIClient = apiClient
+			}
 			return runStatus(opts)
 		},
 	}
@@ -53,10 +60,11 @@ func NewCmdStatus(ctx *cmd.Context) *cmd.Command {
 
 // StatusOpts defines the options for the `auth status` command.
 type StatusOpts struct {
-	Ctx     context.Context
-	IO      iostreams.IOStreams
-	Profile *profile.Profile
-	Output  *format.Outputter
+	Ctx       context.Context
+	IO        iostreams.IOStreams
+	Profile   *profile.Profile
+	Output    *format.Outputter
+	APIClient *client.Client
 }
 
 // StatusResult is the structured output for auth status.
@@ -79,15 +87,7 @@ func runStatus(opts *StatusOpts) error {
 		return displayUnauthorized(opts, hostname)
 	}
 
-	// Build a one-off API client from the profile.
-	address := opts.Profile.Hostname
-	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
-		address = "https://" + address
-	}
-	apiClient, err := client.New(address, opts.Profile.Token, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
+	apiClient := opts.APIClient
 
 	// Call /account/details.
 	resp, err := apiClient.TFE.API.Account().Details().Get(opts.Ctx, nil)

--- a/internal/commands/auth/status.go
+++ b/internal/commands/auth/status.go
@@ -6,12 +6,9 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
-
-	tfe "github.com/hashicorp/go-tfe"
 
 	"github.com/hashicorp/tfctl-cli/internal/config"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
@@ -65,8 +62,8 @@ type StatusOpts struct {
 // StatusResult is the structured output for auth status.
 type StatusResult struct {
 	Hostname  string     `json:"hostname"`
-	Username  string     `json:"username"`
-	TokenType string     `json:"token_type"`
+	Username  string     `json:"username,omitempty"`
+	TokenType string     `json:"token_type,omitempty"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 	Active    bool       `json:"active"`
 }
@@ -77,12 +74,9 @@ func runStatus(opts *StatusOpts) error {
 		hostname = defaultHostname
 	}
 
-	cs := opts.IO.ColorScheme()
-
 	// No token configured at all.
 	if opts.Profile.Token == "" {
-		fmt.Fprintf(opts.IO.Err(), "%s Unauthorized for %s\n", cs.FailureIcon(), hostname)
-		return cmd.ErrUnderlyingError
+		return displayUnauthorized(opts, hostname)
 	}
 
 	// Build a one-off API client from the profile.
@@ -98,13 +92,7 @@ func runStatus(opts *StatusOpts) error {
 	// Call /account/details.
 	resp, err := apiClient.TFE.API.Account().Details().Get(opts.Ctx, nil)
 	if err != nil {
-		fmt.Fprintf(opts.IO.Err(), "%s Unauthorized for %s\n", cs.FailureIcon(), hostname)
-
-		var apiErr *tfe.APIError
-		if errors.As(err, &apiErr) {
-			return cmd.ErrUnderlyingError
-		}
-		return cmd.ErrUnderlyingError
+		return displayUnauthorized(opts, hostname)
 	}
 
 	data := resp.GetData()
@@ -162,11 +150,28 @@ func runStatus(opts *StatusOpts) error {
 	return opts.Output.Display(&statusDisplayer{result: result, io: opts.IO})
 }
 
+// displayUnauthorized emits a machine-readable inactive result for JSON/agent
+// consumers and writes the human-readable failure message to stderr. It always
+// returns cmd.ErrUnderlyingError so callers can tail-call it.
+func displayUnauthorized(opts *StatusOpts, hostname string) error {
+	if opts.Output.GetFormat().IsJSONOrAgent() {
+		result := &StatusResult{Active: false, Hostname: hostname}
+		// Best-effort: ignore display errors since we are already in a failure path.
+		_ = opts.Output.Display(&statusDisplayer{result: result, io: opts.IO})
+	}
+	cs := opts.IO.ColorScheme()
+	fmt.Fprintf(opts.IO.Err(), "%s Unauthorized for %s\n", cs.FailureIcon(), hostname)
+	return cmd.ErrUnderlyingError
+}
+
 // fetchTokenExpiration follows the auth-token link and returns the expiration
 // time if available. Returns nil on any error (best-effort).
 func fetchTokenExpiration(ctx context.Context, apiClient *client.Client, path string) *time.Time {
-	// The path from the API is absolute (e.g., /api/v2/authentication-tokens/at-xxx).
-	// Build the URL from the base URL's scheme+host, not using the full API base path.
+	// The path from the API is already root-absolute (e.g. /api/v2/authentication-tokens/at-xxx),
+	// so we replace BaseURL.Path entirely rather than appending to it.
+	// Do NOT use client.ResolveURL here: that helper appends to the base path
+	// (which already contains /api/v2), which would produce a double-prefixed
+	// path like /api/v2/api/v2/authentication-tokens/at-xxx.
 	tokenURL := *apiClient.BaseURL
 	tokenURL.Path = path
 	tokenURL.RawQuery = ""

--- a/internal/commands/auth/status.go
+++ b/internal/commands/auth/status.go
@@ -1,0 +1,239 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+
+	"github.com/hashicorp/tfctl-cli/internal/config"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/heredoc"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/profile"
+)
+
+// NewCmdStatus returns the `auth status` command for displaying auth info.
+func NewCmdStatus(ctx *cmd.Context) *cmd.Command {
+	opts := &StatusOpts{
+		Ctx:     ctx.ShutdownCtx,
+		IO:      ctx.IO,
+		Profile: ctx.Profile,
+		Output:  ctx.Output,
+	}
+
+	cmd := &cmd.Command{
+		Name:      "status",
+		ShortHelp: "Display information about the current authentication.",
+		LongHelp: heredoc.New(ctx.IO).Mustf(`
+		The {{ template "mdCodeOrBold" "%s auth status" }} command displays
+		information about the currently authenticated account and token,
+		including when the token expires if that information is available.
+		`, config.Name),
+		Examples: []cmd.Example{
+			{
+				Preamble: "Show authentication status:",
+				Command:  fmt.Sprintf("$ %s auth status", config.Name),
+			},
+		},
+		NoAuthRequired: true,
+		RunF: func(_ *cmd.Command, _ []string) error {
+			return runStatus(opts)
+		},
+	}
+
+	return cmd
+}
+
+// StatusOpts defines the options for the `auth status` command.
+type StatusOpts struct {
+	Ctx     context.Context
+	IO      iostreams.IOStreams
+	Profile *profile.Profile
+	Output  *format.Outputter
+}
+
+// StatusResult is the structured output for auth status.
+type StatusResult struct {
+	Hostname  string     `json:"hostname"`
+	Username  string     `json:"username"`
+	TokenType string     `json:"token_type"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Active    bool       `json:"active"`
+}
+
+func runStatus(opts *StatusOpts) error {
+	hostname := opts.Profile.Hostname
+	if hostname == "" {
+		hostname = defaultHostname
+	}
+
+	cs := opts.IO.ColorScheme()
+
+	// No token configured at all.
+	if opts.Profile.Token == "" {
+		fmt.Fprintf(opts.IO.Err(), "%s Unauthorized for %s\n", cs.FailureIcon(), hostname)
+		return cmd.ErrUnderlyingError
+	}
+
+	// Build a one-off API client from the profile.
+	address := opts.Profile.Hostname
+	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
+		address = "https://" + address
+	}
+	apiClient, err := client.New(address, opts.Profile.Token, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	// Call /account/details.
+	resp, err := apiClient.TFE.API.Account().Details().Get(opts.Ctx, nil)
+	if err != nil {
+		fmt.Fprintf(opts.IO.Err(), "%s Unauthorized for %s\n", cs.FailureIcon(), hostname)
+
+		var apiErr *tfe.APIError
+		if errors.As(err, &apiErr) {
+			return cmd.ErrUnderlyingError
+		}
+		return cmd.ErrUnderlyingError
+	}
+
+	data := resp.GetData()
+	if data == nil {
+		return fmt.Errorf("empty response from account details")
+	}
+
+	attrs := data.GetAttributes()
+	if attrs == nil || attrs.GetUsername() == nil {
+		return fmt.Errorf("no username in account details response")
+	}
+
+	username := *attrs.GetUsername()
+
+	// Determine token type from the authenticated-resource relationship.
+	tokenType := "user"
+	rels := data.GetRelationships()
+	if rels != nil {
+		if authRes := rels.GetAuthenticatedResource(); authRes != nil {
+			if authResData := authRes.GetData(); authResData != nil {
+				if t := authResData.GetTypeEscaped(); t != nil {
+					tokenType = t.String()
+				}
+			}
+		}
+	}
+
+	// Follow the auth-token link for expiration information.
+	var expiresAt *time.Time
+	if links := data.GetLinks(); links != nil {
+		if authTokenPath, ok := links.GetAdditionalData()["auth-token"]; ok {
+			var pathStr string
+			switch v := authTokenPath.(type) {
+			case string:
+				pathStr = v
+			case *string:
+				if v != nil {
+					pathStr = *v
+				}
+			}
+			if pathStr != "" {
+				expiresAt = fetchTokenExpiration(opts.Ctx, apiClient, pathStr)
+			}
+		}
+	}
+
+	result := &StatusResult{
+		Hostname:  hostname,
+		Username:  username,
+		TokenType: tokenType,
+		ExpiresAt: expiresAt,
+		Active:    true,
+	}
+
+	return opts.Output.Display(&statusDisplayer{result: result, io: opts.IO})
+}
+
+// fetchTokenExpiration follows the auth-token link and returns the expiration
+// time if available. Returns nil on any error (best-effort).
+func fetchTokenExpiration(ctx context.Context, apiClient *client.Client, path string) *time.Time {
+	// The path from the API is absolute (e.g., /api/v2/authentication-tokens/at-xxx).
+	// Build the URL from the base URL's scheme+host, not using the full API base path.
+	tokenURL := *apiClient.BaseURL
+	tokenURL.Path = path
+	tokenURL.RawQuery = ""
+	tokenURL.Fragment = ""
+
+	resp, err := apiClient.RawRequest(ctx, &client.Request{
+		Method: "GET",
+		URL:    &tokenURL,
+	})
+	if err != nil || resp.StatusCode != 200 {
+		return nil
+	}
+
+	var tokenResp struct {
+		Data struct {
+			Attributes struct {
+				ExpiredAt *time.Time `json:"expired-at"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body, &tokenResp); err != nil {
+		return nil
+	}
+
+	return tokenResp.Data.Attributes.ExpiredAt
+}
+
+// statusDisplayer implements format.Displayer and format.StringPayload.
+type statusDisplayer struct {
+	result *StatusResult
+	io     iostreams.IOStreams
+}
+
+var (
+	_ format.Displayer     = (*statusDisplayer)(nil)
+	_ format.StringPayload = (*statusDisplayer)(nil)
+)
+
+func (d *statusDisplayer) DefaultFormat() format.Format { return format.Pretty }
+func (d *statusDisplayer) Payload() any                 { return d.result }
+func (d *statusDisplayer) FieldTemplates() []format.Field {
+	return nil
+}
+
+// StringPayload returns pre-formatted output for pretty and markdown formats.
+func (d *statusDisplayer) StringPayload(f format.Format) string {
+	var sb strings.Builder
+	cs := d.io.ColorScheme()
+
+	switch f {
+	case format.Markdown:
+		fmt.Fprintf(&sb, "Logged in to %s (%s: %s)", d.result.Hostname, d.result.TokenType, d.result.Username)
+		if d.result.ExpiresAt != nil {
+			fmt.Fprintf(&sb, "\nToken expires: %s", d.result.ExpiresAt.Format(time.RFC3339))
+		}
+	default:
+		fmt.Fprintf(&sb, "%s Logged in to %s (%s: %s)",
+			cs.SuccessIcon(),
+			d.result.Hostname,
+			d.result.TokenType,
+			cs.String(d.result.Username).Bold())
+		if d.result.ExpiresAt != nil {
+			fmt.Fprintf(&sb, "\n%s Token expires: %s",
+				cs.SuccessIcon(),
+				d.result.ExpiresAt.Format(time.RFC3339))
+		}
+	}
+
+	return sb.String()
+}

--- a/internal/commands/auth/status_test.go
+++ b/internal/commands/auth/status_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/profile"
@@ -91,6 +92,14 @@ func newFakeStatusTFE(t *testing.T, username, tokenType, tokenID, expiredAt stri
 	return srv
 }
 
+// newStatusClient returns a *client.Client pointed at srv, for use in StatusOpts.
+func newStatusClient(t *testing.T, srv *httptest.Server) *client.Client {
+	t.Helper()
+	c, err := client.New(srv.URL, "test-token", nil)
+	require.NoError(t, err)
+	return c
+}
+
 func TestStatus_Success(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
@@ -105,10 +114,11 @@ func TestStatus_Success(t *testing.T) {
 	output := format.New(io)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))
@@ -131,10 +141,11 @@ func TestStatus_Success_NoExpiration(t *testing.T) {
 	output := format.New(io)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))
@@ -157,10 +168,11 @@ func TestStatus_Success_NoTokenLink(t *testing.T) {
 	output := format.New(io)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))
@@ -183,10 +195,11 @@ func TestStatus_Unauthorized(t *testing.T) {
 	output := format.New(io)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	err := runStatus(opts)
@@ -235,10 +248,11 @@ func TestStatus_JSONOutput(t *testing.T) {
 	output.SetFormat(format.JSON)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))
@@ -263,10 +277,11 @@ func TestStatus_MarkdownOutput(t *testing.T) {
 	output.SetFormat(format.Markdown)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))
@@ -288,10 +303,11 @@ func TestStatus_OrganizationToken(t *testing.T) {
 	output := format.New(io)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))
@@ -313,10 +329,11 @@ func TestStatus_TeamToken(t *testing.T) {
 	output := format.New(io)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))
@@ -339,10 +356,11 @@ func TestStatus_QuietMode(t *testing.T) {
 	output := format.New(io)
 
 	opts := &StatusOpts{
-		Ctx:     context.Background(),
-		IO:      io,
-		Profile: p,
-		Output:  output,
+		Ctx:       context.Background(),
+		IO:        io,
+		Profile:   p,
+		Output:    output,
+		APIClient: newStatusClient(t, srv),
 	}
 
 	r.NoError(runStatus(opts))

--- a/internal/commands/auth/status_test.go
+++ b/internal/commands/auth/status_test.go
@@ -1,0 +1,376 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/profile"
+)
+
+// newFakeStatusTFE returns an httptest.Server that serves /account/details and
+// optionally /authentication-tokens/{id}. If username is empty, account/details
+// returns 401. If tokenID is non-empty, the auth-token link is included and the
+// token endpoint is registered. If expiredAt is non-empty, it is included in
+// the token attributes.
+func newFakeStatusTFE(t *testing.T, username, tokenType, tokenID, expiredAt string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v2/account/details", func(w http.ResponseWriter, r *http.Request) {
+		if username == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"errors":[{"status":"401","title":"unauthorized"}]}`)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+
+		authTokenLink := ""
+		if tokenID != "" {
+			authTokenLink = fmt.Sprintf(`,"auth-token":"/api/v2/authentication-tokens/%s"`, tokenID)
+		}
+
+		authResType := "users"
+		if tokenType != "" {
+			authResType = tokenType
+		}
+
+		fmt.Fprintf(w, `{
+			"data":{
+				"id":"user-abc",
+				"type":"users",
+				"attributes":{"username":%q},
+				"links":{"self":"/api/v2/users/user-abc"%s},
+				"relationships":{
+					"authenticated-resource":{
+						"data":{"id":"user-abc","type":%q},
+						"links":{"related":"/api/v2/users/user-abc"}
+					}
+				}
+			}
+		}`, username, authTokenLink, authResType)
+	})
+
+	if tokenID != "" {
+		mux.HandleFunc("/api/v2/authentication-tokens/"+tokenID, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
+
+			expiredField := `"expired-at":null`
+			if expiredAt != "" {
+				expiredField = fmt.Sprintf(`"expired-at":%q`, expiredAt)
+			}
+
+			fmt.Fprintf(w, `{
+				"data":{
+					"id":%q,
+					"type":"authentication-tokens",
+					"attributes":{
+						"created-at":"2026-01-01T00:00:00.000Z",
+						"description":"test token",
+						%s,
+						"last-used-at":"2026-05-13T00:00:00.000Z",
+						"token":null
+					}
+				}
+			}`, tokenID, expiredField)
+		})
+	}
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestStatus_Success(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "testuser", "users", "at-abc123", "2026-06-01T00:00:00.000Z")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "test-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Contains(io.Output.String(), "Logged in to")
+	r.Contains(io.Output.String(), "testuser")
+	r.Contains(io.Output.String(), "Token expires")
+}
+
+func TestStatus_Success_NoExpiration(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "testuser", "users", "at-abc123", "")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "test-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Contains(io.Output.String(), "Logged in to")
+	r.Contains(io.Output.String(), "testuser")
+	r.NotContains(io.Output.String(), "Token expires")
+}
+
+func TestStatus_Success_NoTokenLink(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "testuser", "users", "", "")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "test-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Contains(io.Output.String(), "Logged in to")
+	r.Contains(io.Output.String(), "testuser")
+	r.NotContains(io.Output.String(), "Token expires")
+}
+
+func TestStatus_Unauthorized(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "", "", "", "")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "bad-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	err := runStatus(opts)
+	r.Error(err)
+	r.Contains(io.Error.String(), "Unauthorized")
+	r.Contains(io.Error.String(), srv.URL)
+}
+
+func TestStatus_NoToken(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	p := profile.TestProfile(t)
+	p.Hostname = "app.terraform.io"
+	p.Token = ""
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	err := runStatus(opts)
+	r.Error(err)
+	r.Contains(io.Error.String(), "Unauthorized")
+	r.Contains(io.Error.String(), "app.terraform.io")
+}
+
+func TestStatus_JSONOutput(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "testuser", "users", "at-abc123", "2026-06-01T00:00:00.000Z")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "test-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+	output.SetFormat(format.JSON)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Contains(io.Output.String(), `"hostname"`)
+	r.Contains(io.Output.String(), `"username"`)
+	r.Contains(io.Output.String(), `"testuser"`)
+	r.Contains(io.Output.String(), `"expires_at"`)
+}
+
+func TestStatus_MarkdownOutput(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "testuser", "users", "at-abc123", "2026-06-01T00:00:00.000Z")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "test-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+	output.SetFormat(format.Markdown)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Contains(io.Output.String(), "Logged in to")
+	r.Contains(io.Output.String(), "testuser")
+}
+
+func TestStatus_OrganizationToken(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "orguser", "organizations", "at-org123", "2026-12-01T00:00:00.000Z")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "org-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Contains(io.Output.String(), "organization")
+	r.Contains(io.Output.String(), "orguser")
+}
+
+func TestStatus_TeamToken(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "teamuser", "teams", "at-team456", "")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "team-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Contains(io.Output.String(), "team")
+	r.Contains(io.Output.String(), "teamuser")
+}
+
+func TestStatus_QuietMode(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeStatusTFE(t, "testuser", "users", "at-abc123", "2026-06-01T00:00:00.000Z")
+	p := profile.TestProfile(t)
+	p.Hostname = srv.URL
+	p.Token = "test-token"
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	io.SetQuiet(true)
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	r.NoError(runStatus(opts))
+	r.Empty(io.Error.String())
+	// Output still goes to stdout via displayer
+	r.Contains(io.Output.String(), "Logged in to")
+}
+
+func TestStatus_DefaultHostname(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	p := profile.TestProfile(t)
+	p.Hostname = ""
+	p.Token = ""
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	output := format.New(io)
+
+	opts := &StatusOpts{
+		Ctx:     context.Background(),
+		IO:      io,
+		Profile: p,
+		Output:  output,
+	}
+
+	err := runStatus(opts)
+	r.Error(err)
+	r.Contains(io.Error.String(), "app.terraform.io")
+}

--- a/internal/pkg/cmd/command_internal.go
+++ b/internal/pkg/cmd/command_internal.go
@@ -162,7 +162,7 @@ func notFoundErrorHelp(io iostreams.IOStreams) string {
 	return heredoc.New(io, heredoc.WithPreserveNewlines(), heredoc.WithWidth(0)).Mustf(`
 		Resource not found or you are unauthorized to this action. Check your account permissions.
 
-		  {{ Bold "$ %s auth info" }}
+		  {{ Bold "$ %s auth status" }}
 	`, config.Name)
 }
 


### PR DESCRIPTION
This PR implements `tfctl auth status`.

### Testing

```
# Authorized profile
❯ ./bin/tfctl auth status
✓ Logged in to tfcdev-781a2fe5.ngrok.io (users: admin)
✓ Token expires: 2026-06-07T18:06:50Z

# Unauthorized profile
❯ ./bin/tfctl auth status --profile ci_instance
X Unauthorized for tflocal-zone-amazingly-regular-bluebird.ngrok.app
```
