### PR TITLE
format: markdown, pretty output improvements

### DIFF
--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -124,13 +124,13 @@ func (d JSONAPIDisplayer) FieldTemplates() []Field {
 		if att == "external-id" {
 			name = "id"
 		}
-		result[i] = NewField(kebabToCapital(name), fmt.Sprintf(`{{ index . "%s" }}`, att))
+		result[i] = NewField(kebabToLabel(name), fmt.Sprintf(`{{ index . "%s" }}`, att))
 	}
 
 	return result
 }
 
-func kebabToCapital(input string) string {
+func kebabToLabel(input string) string {
 	caser := cases.Title(language.AmericanEnglish)
 	parts := strings.Split(input, ".")
 	for i, part := range parts {

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -46,12 +46,33 @@ var typeColumns = map[string][]string{
 	"task-stages":                 {"status", "stage", "task-result-count"},
 	"varsets":                     {"name", "description", "global", "priority"},
 	"vars":                        {"key", "value", "category", "hcl", "sensitive"},
-	"workspaces":                  {"name", "description", "execution-mode", "locked", "resource-count"},
+	"workspaces":                  {"name", "description", "project", "execution-mode", "locked", "resource-count"},
 }
 
 var excludeColumns = map[string][]string{
 	"workspaces":    {"actions"},
 	"organizations": {"id"},
+}
+
+// acronyms are capitalized in field names, e.g. "VCS Repo.Repository HTTP URL" instead of "Vcs Repo.Repository Http Url".
+var acronyms = map[string]string{
+	"api":   "API",
+	"cidr":  "CIDR",
+	"http":  "HTTP",
+	"https": "HTTPS",
+	"id":    "ID",
+	"ids":   "IDs",
+	"ip":    "IP",
+	"kpis":  "KPIs",
+	"oauth": "OAuth",
+	"rum":   "RUM",
+	"saml":  "SAML",
+	"scim":  "SCIM",
+	"ssh":   "SSH",
+	"sso":   "SSO",
+	"ttl":   "TTL",
+	"url":   "URL",
+	"vcs":   "VCS",
 }
 
 // JSONAPIDisplayer prepares responses within a JSON:API data envelope to be formatted.
@@ -87,17 +108,13 @@ func (d JSONAPIDisplayer) TemplatedPayload() any {
 
 // FieldTemplates implements the Displayer interface.
 func (d JSONAPIDisplayer) FieldTemplates() []Field {
-	rows := d.payload.([]map[string]any)
-
-	var cols = make([]string, 0, 16)
+	var cols []string
 	if d.DefaultFormat() == Table {
+		rows := d.payload.([]map[string]any)
 		cols = collectColumns(rows, typeColumns[d.resourceType], excludeColumns[d.resourceType])
-	} else if len(rows) > 0 {
-		cols = orderedFields(rows[0], typeColumns[d.resourceType])
-	}
-
-	if slices.Contains(excludeColumns[d.resourceType], "id") && len(cols) > 0 && cols[0] == "id" {
-		cols = cols[1:]
+	} else {
+		rows := d.payload.(map[string]any)
+		cols = orderedFields(rows, typeColumns[d.resourceType])
 	}
 
 	result := make([]Field, len(cols))
@@ -114,11 +131,19 @@ func (d JSONAPIDisplayer) FieldTemplates() []Field {
 }
 
 func kebabToCapital(input string) string {
-	caser := cases.Title(language.English)
+	caser := cases.Title(language.AmericanEnglish)
 	parts := strings.Split(input, ".")
 	for i, part := range parts {
-		spaced := strings.ReplaceAll(part, "-", " ")
-		parts[i] = caser.String(spaced)
+		spacedParts := strings.Split(part, "-")
+		for j, spacedPart := range spacedParts {
+			if acronym, ok := acronyms[spacedPart]; ok {
+				spacedParts[j] = acronym
+			} else {
+				spacedParts[j] = caser.String(spacedPart)
+			}
+		}
+
+		parts[i] = strings.Join(spacedParts, " ")
 	}
 	return strings.Join(parts, ".")
 }
@@ -127,25 +152,29 @@ func kebabToCapital(input string) string {
 func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 	resourceType := ""
 	collection := true
-	var payload map[string]any
-	if err := json.Unmarshal(raw, &payload); err != nil {
+	var rawPayload map[string]any
+	if err := json.Unmarshal(raw, &rawPayload); err != nil {
 		return nil, ErrNotJSONAPI
 	}
 
-	data, ok := payload["data"]
+	data, ok := rawPayload["data"]
 	if !ok {
 		return nil, ErrNotJSONAPI
 	}
 
-	var rows []map[string]any
+	var payload any
 	switch typed := data.(type) {
 	case []any:
-		for _, item := range typed {
+		payload = make([]map[string]any, len(typed))
+		for i, item := range typed {
 			row, ok := resourceAsMap(item)
 			if !ok {
 				return nil, ErrNotJSONAPI
 			}
-			rows = append(rows, row)
+			if resourceType == "" {
+				resourceType = row["type"].(string)
+			}
+			payload.([]map[string]any)[i] = row
 		}
 	case map[string]any:
 		collection = false
@@ -153,40 +182,18 @@ func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 		if !ok {
 			return nil, ErrNotJSONAPI
 		}
-		rows = append(rows, row)
+		payload = row
+		resourceType = row["type"].(string)
 	default:
 		return nil, ErrNotJSONAPI
 	}
 
-	if len(rows) > 0 {
-		resourceType = stringValue(rows[0]["type"])
-	}
-
 	return &JSONAPIDisplayer{
-		payload:      rows,
-		rawPayload:   payload,
+		payload:      payload,
+		rawPayload:   rawPayload,
 		resourceType: resourceType,
 		collection:   collection,
 	}, nil
-}
-
-func stringValue(value any) string {
-	switch v := value.(type) {
-	case nil:
-		return "null"
-	case string:
-		return v
-	case bool, float64, int, int64:
-		return fmt.Sprint(v)
-	case json.Number:
-		return v.String()
-	default:
-		encoded, err := json.Marshal(v)
-		if err != nil {
-			return fmt.Sprint(v)
-		}
-		return string(encoded)
-	}
 }
 
 func resourceAsMap(item any) (map[string]any, bool) {
@@ -211,6 +218,25 @@ func resourceAsMap(item any) (map[string]any, bool) {
 	if !ok {
 		return nil, false
 	}
+
+	// Look for one-to-one relationships and pull the ID up to the top level of the row for display.
+	rels, ok := obj["relationships"]
+	if ok {
+		for rel, relData := range rels.(map[string]any) {
+			relObj, ok := relData.(map[string]any)
+			if !ok {
+				continue
+			}
+			data, ok := relObj["data"]
+			if !ok {
+				continue
+			}
+			if oneToOne, isOneToOne := data.(map[string]any); isOneToOne {
+				attrMap[rel] = oneToOne["id"]
+			}
+		}
+	}
+
 	for key, value := range attrMap {
 		row[key] = value
 	}

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -171,8 +171,10 @@ func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 			if !ok {
 				return nil, ErrNotJSONAPI
 			}
-			if resourceType == "" {
-				resourceType = row["type"].(string)
+			if resourceType == "" && row["type"] != nil {
+				if rt, ok := row["type"].(string); ok {
+					resourceType = rt
+				}
 			}
 			payload.([]map[string]any)[i] = row
 		}
@@ -183,7 +185,11 @@ func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 			return nil, ErrNotJSONAPI
 		}
 		payload = row
-		resourceType = row["type"].(string)
+		if row["type"] != nil {
+			if rt, ok := row["type"].(string); ok {
+				resourceType = rt
+			}
+		}
 	default:
 		return nil, ErrNotJSONAPI
 	}

--- a/internal/pkg/format/markdown.go
+++ b/internal/pkg/format/markdown.go
@@ -26,9 +26,6 @@ func (o *Outputter) outputMarkdown(d Displayer) error {
 		headers[i] = f.Name
 	}
 
-	// Create the table outputter
-	tbl := table.MarkdownTable{}
-
 	// Get the payload
 	var p any
 	if tp, ok := d.(TemplatedPayload); ok {
@@ -36,6 +33,9 @@ func (o *Outputter) outputMarkdown(d Displayer) error {
 	} else {
 		p = d.Payload()
 	}
+
+	// Create the table outputter
+	tbl := table.MarkdownTable{}
 
 	// Build the rows
 	var rows [][]interface{}
@@ -60,7 +60,7 @@ func (o *Outputter) outputMarkdown(d Displayer) error {
 		// it to the table.
 		tbl.AddRow("Field", "Value")
 		for _, f := range fields {
-			row, err := renderNameValue(p, f.Name, fields)
+			row, err := renderNameValue(rv.Interface(), f.Name, fields)
 			if err != nil {
 				return err
 			}
@@ -80,7 +80,7 @@ func (o *Outputter) outputMarkdown(d Displayer) error {
 	return nil
 }
 
-// renderRow renders each field by executing the text/template given the
+// renderNameValue renders each field by executing the text/template given the
 // payload.
 func renderNameValue(p any, name string, fields []Field) ([]interface{}, error) {
 	renderedFields := make([]interface{}, 2)

--- a/internal/pkg/format/output.go
+++ b/internal/pkg/format/output.go
@@ -445,7 +445,7 @@ func (o *Outputter) outputPretty(d Displayer) error {
 		p = d.Payload()
 	}
 
-	tmpl, err := template.New("cli").Parse(prettyPrintTemplate(d))
+	tmpl, err := template.New("cli").Parse(prettyPrintTemplate(d, o.io.ColorScheme()))
 	if err != nil {
 		return err
 	}
@@ -481,7 +481,7 @@ func (o *Outputter) outputPretty(d Displayer) error {
 
 // prettyPrintTemplate returns a text/template string for pretty printing the
 // given payload. The template will align the values so they are easily scannable.
-func prettyPrintTemplate(d Displayer) string {
+func prettyPrintTemplate(d Displayer, cs *iostreams.ColorScheme) string {
 	// Write to the buffer using a tabwriter. The Tabwriter will ensure that
 	// each key/value is aligned.
 	var buf bytes.Buffer
@@ -490,7 +490,11 @@ func prettyPrintTemplate(d Displayer) string {
 	// Go through each field and output a new line
 	fields := d.FieldTemplates()
 	for i, f := range fields {
-		fmt.Fprintf(w, "%s:\t%s", f.Name, f.ValueFormat)
+		fmt.Fprint(w, cs.String(f.Name).Bold().Color(cs.LightGreen()).String())
+		fmt.Fprint(w, ":\t")
+		// Limitation of field templates: ValueFormat is a text template but without the context of
+		// io/heredoc template functions.
+		fmt.Fprint(w, f.ValueFormat)
 		if i != len(fields)-1 {
 			fmt.Fprintln(w)
 		}

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -183,18 +183,13 @@ func TestWithJSONAPIResource(t *testing.T) {
   }
 }`
 
-	disp, err := format.NewJSONAPIDisplayer([]byte(j))
-	r.NoError(err)
-
-	io := iostreams.Test()
-	out := format.New(io)
-	out.SetFormat(format.Pretty)
-	err = out.Display(disp)
-
-	r.NoError(err)
-	fmt.Println(io.Output.String())
-
-	expected := `ID:                                   user-V3R563qtJNcExAkN
+	cases := []struct {
+		format   format.Format
+		expected string
+	}{
+		{
+			format: format.Pretty,
+			expected: `ID:                                   user-V3R563qtJNcExAkN
 Auth Method:                          tfc
 Authenticated Resource:               user-V3R563qtJNcExAkN
 Avatar URL:                           https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm
@@ -218,6 +213,54 @@ Tags.2:                               us-east
 Triple Nested.Level1.Level2.Key:      hello
 Triple Nested.Level1.Level2.Value:    world
 Type:                                 users
-`
-	r.Equal(expected, io.Output.String())
+`,
+		},
+		{
+			format: format.Markdown,
+			expected: `
+| Field                                | Value                                                                       |
+| ------------------------------------ | --------------------------------------------------------------------------- |
+| ID                                   | user-V3R563qtJNcExAkN                                                       |
+| Auth Method                          | tfc                                                                         |
+| Authenticated Resource               | user-V3R563qtJNcExAkN                                                       |
+| Avatar URL                           | https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm |
+| Email                                | admin@hashicorp.com                                                         |
+| Is Service Account                   | false                                                                       |
+| Is Site Admin                        | true                                                                        |
+| Is SSO Login                         | false                                                                       |
+| Unconfirmed Email                    | <no value>                                                                  |
+| Username                             | admin                                                                       |
+| V2 Only                              | false                                                                       |
+| Double Nested.0.Key                  | foo                                                                         |
+| Double Nested.0.Value                | bar                                                                         |
+| Double Nested.1.Key                  | fizz                                                                        |
+| Double Nested.1.Value                | buzz                                                                        |
+| Permissions.Can Change Email         | true                                                                        |
+| Permissions.Can Change Username      | true                                                                        |
+| Permissions.Can Create Organizations | true                                                                        |
+| Tags.0                               | networking                                                                  |
+| Tags.1                               | production                                                                  |
+| Tags.2                               | us-east                                                                     |
+| Triple Nested.Level1.Level2.Key      | hello                                                                       |
+| Triple Nested.Level1.Level2.Value    | world                                                                       |
+| Type                                 | users                                                                       |
+
+`,
+		},
+	}
+
+	disp, err := format.NewJSONAPIDisplayer([]byte(j))
+	r.NoError(err)
+
+	for _, c := range cases {
+		io := iostreams.Test()
+		out := format.New(io)
+		out.SetFormat(c.format)
+		err = out.Display(disp)
+
+		r.NoError(err)
+		fmt.Println(io.Output.String())
+
+		r.Equal(c.expected, io.Output.String())
+	}
 }

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -194,13 +194,14 @@ func TestWithJSONAPIResource(t *testing.T) {
 	r.NoError(err)
 	fmt.Println(io.Output.String())
 
-	expected := `Id:                                   user-V3R563qtJNcExAkN
+	expected := `ID:                                   user-V3R563qtJNcExAkN
 Auth Method:                          tfc
-Avatar Url:                           https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm
+Authenticated Resource:               user-V3R563qtJNcExAkN
+Avatar URL:                           https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm
 Email:                                admin@hashicorp.com
 Is Service Account:                   false
 Is Site Admin:                        true
-Is Sso Login:                         false
+Is SSO Login:                         false
 Unconfirmed Email:                    <no value>
 Username:                             admin
 V2 Only:                              false

--- a/internal/pkg/heredoc/template_funcs.go
+++ b/internal/pkg/heredoc/template_funcs.go
@@ -100,7 +100,6 @@ func getColor(cs *iostreams.ColorScheme, c string) (iostreams.Color, error) {
 		"orange":     cs.Orange,
 		"yellow":     cs.Yellow,
 		"gray":       cs.Gray,
-		"dimblue":    cs.DimBlue,
 		"lightgreen": cs.LightGreen,
 	}
 

--- a/internal/pkg/heredoc/template_funcs.go
+++ b/internal/pkg/heredoc/template_funcs.go
@@ -93,13 +93,15 @@ func (f *Formatter) templateFuncs(t *template.Template) template.FuncMap {
 func getColor(cs *iostreams.ColorScheme, c string) (iostreams.Color, error) {
 	c = strings.ToLower(c)
 	valid := map[string]func() iostreams.Color{
-		"white":  cs.White,
-		"black":  cs.Black,
-		"red":    cs.Red,
-		"green":  cs.Green,
-		"orange": cs.Orange,
-		"yellow": cs.Yellow,
-		"gray":   cs.Gray,
+		"white":      cs.White,
+		"black":      cs.Black,
+		"red":        cs.Red,
+		"green":      cs.Green,
+		"orange":     cs.Orange,
+		"yellow":     cs.Yellow,
+		"gray":       cs.Gray,
+		"dimblue":    cs.DimBlue,
+		"lightgreen": cs.LightGreen,
 	}
 
 	if strings.HasPrefix(c, "#") {

--- a/internal/pkg/iostreams/colorscheme.go
+++ b/internal/pkg/iostreams/colorscheme.go
@@ -17,7 +17,6 @@ const (
 	orange     = "#BB5A00"
 	yellow     = "#FFD814"
 	gray       = "#C2C5CB"
-	dimblue    = "#BDC7F0"
 	lightgreen = "#73DACA"
 )
 
@@ -234,13 +233,6 @@ func (cs *ColorScheme) Yellow() Color {
 func (cs *ColorScheme) Gray() Color {
 	return Color{
 		color: cs.profile.Color(gray),
-	}
-}
-
-// DimBlue is a dim blue color.
-func (cs *ColorScheme) DimBlue() Color {
-	return Color{
-		color: cs.profile.Color(dimblue),
 	}
 }
 

--- a/internal/pkg/iostreams/colorscheme.go
+++ b/internal/pkg/iostreams/colorscheme.go
@@ -10,13 +10,15 @@ import (
 const (
 	// Each constant defines the color code for the given color. A # prefix
 	// indicates RGB colors, and a number indicates ANSI colors.
-	black  = "0"
-	white  = "7"
-	red    = "#E52228"
-	green  = "#008A22"
-	orange = "#BB5A00"
-	yellow = "#FFD814"
-	gray   = "#C2C5CB"
+	black      = "0"
+	white      = "7"
+	red        = "#E52228"
+	green      = "#008A22"
+	orange     = "#BB5A00"
+	yellow     = "#FFD814"
+	gray       = "#C2C5CB"
+	dimblue    = "#BDC7F0"
+	lightgreen = "#73DACA"
 )
 
 // Emphasis is used to style text.
@@ -232,6 +234,20 @@ func (cs *ColorScheme) Yellow() Color {
 func (cs *ColorScheme) Gray() Color {
 	return Color{
 		color: cs.profile.Color(gray),
+	}
+}
+
+// DimBlue is a dim blue color.
+func (cs *ColorScheme) DimBlue() Color {
+	return Color{
+		color: cs.profile.Color(dimblue),
+	}
+}
+
+// LightGreen is a light green color.
+func (cs *ColorScheme) LightGreen() Color {
+	return Color{
+		color: cs.profile.Color(lightgreen),
 	}
 }
 


### PR DESCRIPTION
- Color in pretty TTY rendering
- Improved Single-resource markdown rendering
- Acronym translation "Sso" -> "SSO"
- Render one-to-one JSON:API relationships in JSONAPIDisplayer output

## Screenshots

<img width="1193" height="825" alt="Screenshot 2026-05-14 at 14 08 07" src="https://github.com/user-attachments/assets/5e0c5603-6f03-49cd-9d95-e71ceba8afe0" />

<img width="1193" height="825" alt="Screenshot 2026-05-14 at 14 08 17" src="https://github.com/user-attachments/assets/72becb9b-6ce4-40ec-a150-0e894d9d23d0" />

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

