### PR TITLE
fix: quotes and other non-attributes in embedded attribute keys

### DIFF
--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -474,7 +474,7 @@ func runAPI(opts *Opts) error {
 		return nil
 	}
 
-	if response.Header.Get("Content-Type") != "application/vnd.api+json" {
+	if !strings.HasPrefix(response.Header.Get("Content-Type"), "application/vnd.api+json") {
 		opts.Logger.Debug("Response body was not application/vnd.api+json, rendering raw body")
 		_, _ = io.Copy(opts.IO.Out(), response.Body)
 		return nil
@@ -486,7 +486,7 @@ func runAPI(opts *Opts) error {
 	}
 
 	// Render the result
-	disp, err := format.NewJSONAPIDisplayer(body)
+	disp, err := format.NewJSONAPIDisplayer(body, opts.Logger)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -58,6 +58,43 @@ func TestRunAPI_DefaultGet(t *testing.T) {
 	require.Empty(t, io.Error.String())
 }
 
+func TestRunAPI_GetContainingQuotes(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/thing": func(w http.ResponseWriter, r *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{
+						"id":   "th-1",
+						"type": "things",
+						"attributes": map[string]any{
+							"name":  "big-goose",
+							"value": "a value with \"quotes\" and 'single quotes'",
+							"user-data": map[string]any{
+								"providers.provider[\"registry.terraform.io/hashicorp/aws\"].aws_ec2_transit_gateway": "aws",
+							},
+						},
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := runAPI(newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/thing")
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, "GET", recorder.Last().Method)
+	require.Equal(t, "/api/v2/thing", recorder.Last().Path)
+	require.Equal(t, "application/vnd.api+json", recorder.Last().Headers.Get("Accept"))
+	require.Contains(t, io.Output.String(), "big-goose")
+	require.Empty(t, io.Error.String())
+}
+
 func TestRunAPI_AttributesInferPostAndResourceType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/go-hclog"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -51,8 +52,9 @@ var typeColumns = map[string][]string{
 }
 
 var excludeColumns = map[string][]string{
-	"workspaces":    {"actions"},
-	"organizations": {"id"},
+	"workspaces":            {"actions"},
+	"organizations":         {"id"},
+	"state-version-outputs": {"detailed-type"},
 }
 
 // acronyms are capitalized in field names, e.g. "VCS Repo.Repository HTTP URL" instead of "Vcs Repo.Repository Http Url".
@@ -84,6 +86,7 @@ type JSONAPIDisplayer struct {
 	rawPayload   any
 	resourceType string
 	collection   bool
+	logger       hclog.Logger
 }
 
 // Check interface at compile time.
@@ -122,7 +125,7 @@ func (d JSONAPIDisplayer) FieldTemplates() []Field {
 		cols = collectColumns(rows, typeColumns[d.resourceType], excludeColumns[d.resourceType])
 	} else {
 		rows := d.payload.(map[string]any)
-		cols = orderedFields(rows, typeColumns[d.resourceType])
+		cols = orderedFields(rows, typeColumns[d.resourceType], excludeColumns[d.resourceType])
 	}
 
 	result := make([]Field, 0, len(cols))
@@ -136,7 +139,13 @@ func (d JSONAPIDisplayer) FieldTemplates() []Field {
 
 		// Skip attributes that contain keys that don't look like API attributes. Certain output values
 		// may be user data, such as the object value of a state version output.
-		if att == sentinelResourceType || reAttributeNameDisallow.MatchString(att) {
+		if name == sentinelResourceType {
+			if d.DefaultFormat() != Table {
+				result = append(result, NewField("Resource", fmt.Sprintf(`{{ index . "%s" }}`, sentinelResourceType)))
+			}
+			continue
+		} else if reAttributeNameDisallow.MatchString(name) {
+			d.logger.Debug("Skipping attribute for display due to invalid characters", "attribute", att)
 			continue
 		}
 
@@ -165,7 +174,7 @@ func kebabToLabel(input string) string {
 }
 
 // NewJSONAPIDisplayer creates a new displayer based on the contents of a JSON:API response body.
-func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
+func NewJSONAPIDisplayer(raw []byte, logger hclog.Logger) (*JSONAPIDisplayer, error) {
 	resourceType := ""
 	collection := true
 	var rawPayload map[string]any
@@ -215,6 +224,7 @@ func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 		rawPayload:   rawPayload,
 		resourceType: resourceType,
 		collection:   collection,
+		logger:       logger,
 	}, nil
 }
 
@@ -297,13 +307,18 @@ func flattenRow(row map[string]any) {
 	}
 }
 
-func orderedFields(row map[string]any, preferred []string) []string {
+func orderedFields(row map[string]any, preferred []string, exclude []string) []string {
 	seen := make(map[string]struct{}, len(row))
 	ordered := make([]string, 0, len(row))
 	if _, ok := row["id"]; ok {
 		ordered = append(ordered, "id")
 		seen["id"] = struct{}{}
 	}
+	if _, ok := row[sentinelResourceType]; ok {
+		ordered = append(ordered, sentinelResourceType)
+		seen[sentinelResourceType] = struct{}{}
+	}
+
 	for _, key := range preferred {
 		if _, ok := row[key]; ok {
 			ordered = append(ordered, key)
@@ -313,28 +328,30 @@ func orderedFields(row map[string]any, preferred []string) []string {
 
 	remaining := make([]string, 0, len(row)-len(ordered))
 	nested := make([]string, 0, len(row))
-	typeTrailer := false
 	for key := range row {
 		if _, ok := seen[key]; ok {
 			continue
 		}
-		if key == "type" {
-			typeTrailer = true
-			continue
-		}
+
+		shouldExclude := slices.ContainsFunc(exclude, func(s string) bool {
+			return s == key || strings.HasPrefix(key, s+".")
+		})
+
 		if isNestedValue(row[key]) || isNestedKey(key) {
-			nested = append(nested, key)
+			if !shouldExclude {
+				nested = append(nested, key)
+			}
 			continue
 		}
-		remaining = append(remaining, key)
+
+		if !shouldExclude {
+			remaining = append(remaining, key)
+		}
 	}
 	sort.Strings(remaining)
 	sort.Strings(nested)
 	ordered = append(ordered, remaining...)
 	ordered = append(ordered, nested...)
-	if typeTrailer {
-		ordered = append(ordered, "type")
-	}
 	return ordered
 }
 
@@ -380,7 +397,14 @@ func collectColumns(rows []map[string]any, preferred []string, exclude []string)
 
 	remaining := make([]string, 0, len(seen))
 	for key := range seen {
-		if exclude == nil || !slices.Contains(exclude, key) {
+		shouldExclude := slices.ContainsFunc(exclude, func(s string) bool {
+			if s == key || strings.HasPrefix(key, s+".") {
+				return true
+			}
+			return false
+		})
+
+		if !shouldExclude {
 			remaining = append(remaining, key)
 		}
 	}

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -89,7 +89,10 @@ type JSONAPIDisplayer struct {
 // Check interface at compile time.
 var _ Displayer = JSONAPIDisplayer{}
 
-var attributeNameRegex = regexp.MustCompile(`^[a-zA-Z]+([._-][a-zA-Z0-9]+)*$`)
+// Any attribute keys that contain characters other than letters, numbers, hyphens, underscores,
+// and periods are skipped for display. Usually indicates user content in embedded
+// objects attributes.
+var reAttributeNameDisallow = regexp.MustCompile(`[^-_.a-zA-Z0-9]`)
 
 // DefaultFormat implements the Displayer interface.
 func (d JSONAPIDisplayer) DefaultFormat() Format {
@@ -126,13 +129,14 @@ func (d JSONAPIDisplayer) FieldTemplates() []Field {
 
 	for _, att := range cols {
 		name := att
+		// Nasty special case for organizations
 		if att == "external-id" {
 			name = "id"
 		}
 
 		// Skip attributes that contain keys that don't look like API attributes. Certain output values
 		// may be user data, such as the object value of a state version output.
-		if !attributeNameRegex.MatchString(att) {
+		if att == sentinelResourceType || reAttributeNameDisallow.MatchString(att) {
 			continue
 		}
 

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -75,6 +76,8 @@ var acronyms = map[string]string{
 	"vcs":   "VCS",
 }
 
+const sentinelResourceType = "__JSONAPI_RESOURCE_TYPE__"
+
 // JSONAPIDisplayer prepares responses within a JSON:API data envelope to be formatted.
 type JSONAPIDisplayer struct {
 	payload      any
@@ -85,6 +88,8 @@ type JSONAPIDisplayer struct {
 
 // Check interface at compile time.
 var _ Displayer = JSONAPIDisplayer{}
+
+var attributeNameRegex = regexp.MustCompile(`^[a-zA-Z]+([._-][a-zA-Z0-9]+)*$`)
 
 // DefaultFormat implements the Displayer interface.
 func (d JSONAPIDisplayer) DefaultFormat() Format {
@@ -117,14 +122,21 @@ func (d JSONAPIDisplayer) FieldTemplates() []Field {
 		cols = orderedFields(rows, typeColumns[d.resourceType])
 	}
 
-	result := make([]Field, len(cols))
+	result := make([]Field, 0, len(cols))
 
-	for i, att := range cols {
+	for _, att := range cols {
 		name := att
 		if att == "external-id" {
 			name = "id"
 		}
-		result[i] = NewField(kebabToLabel(name), fmt.Sprintf(`{{ index . "%s" }}`, att))
+
+		// Skip attributes that contain keys that don't look like API attributes. Certain output values
+		// may be user data, such as the object value of a state version output.
+		if !attributeNameRegex.MatchString(att) {
+			continue
+		}
+
+		result = append(result, NewField(kebabToLabel(name), fmt.Sprintf(`{{ index . "%s" }}`, att)))
 	}
 
 	return result
@@ -171,8 +183,8 @@ func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 			if !ok {
 				return nil, ErrNotJSONAPI
 			}
-			if resourceType == "" && row["type"] != nil {
-				if rt, ok := row["type"].(string); ok {
+			if resourceType == "" && row[sentinelResourceType] != nil {
+				if rt, ok := row[sentinelResourceType].(string); ok {
 					resourceType = rt
 				}
 			}
@@ -185,8 +197,8 @@ func NewJSONAPIDisplayer(raw []byte) (*JSONAPIDisplayer, error) {
 			return nil, ErrNotJSONAPI
 		}
 		payload = row
-		if row["type"] != nil {
-			if rt, ok := row["type"].(string); ok {
+		if row[sentinelResourceType] != nil {
+			if rt, ok := row[sentinelResourceType].(string); ok {
 				resourceType = rt
 			}
 		}
@@ -213,7 +225,7 @@ func resourceAsMap(item any) (map[string]any, bool) {
 		row["id"] = id
 	}
 	if kind, ok := obj["type"]; ok {
-		row["type"] = kind
+		row[sentinelResourceType] = kind
 	}
 
 	attrs, ok := obj["attributes"]

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
 )
@@ -190,6 +192,7 @@ func TestWithJSONAPIResource(t *testing.T) {
 		{
 			format: format.Pretty,
 			expected: `ID:                                   user-V3R563qtJNcExAkN
+Resource:                             users
 Auth Method:                          tfc
 Authenticated Resource:               user-V3R563qtJNcExAkN
 Avatar URL:                           https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm
@@ -220,6 +223,7 @@ Triple Nested.Level1.Level2.Value:    world
 | Field                                | Value                                                                       |
 | ------------------------------------ | --------------------------------------------------------------------------- |
 | ID                                   | user-V3R563qtJNcExAkN                                                       |
+| Resource                             | users                                                                       |
 | Auth Method                          | tfc                                                                         |
 | Authenticated Resource               | user-V3R563qtJNcExAkN                                                       |
 | Avatar URL                           | https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm |
@@ -247,7 +251,7 @@ Triple Nested.Level1.Level2.Value:    world
 		},
 	}
 
-	disp, err := format.NewJSONAPIDisplayer([]byte(j))
+	disp, err := format.NewJSONAPIDisplayer([]byte(j), hclog.Default())
 	r.NoError(err)
 
 	for _, c := range cases {

--- a/internal/pkg/format/output_test.go
+++ b/internal/pkg/format/output_test.go
@@ -212,7 +212,6 @@ Tags.1:                               production
 Tags.2:                               us-east
 Triple Nested.Level1.Level2.Key:      hello
 Triple Nested.Level1.Level2.Value:    world
-Type:                                 users
 `,
 		},
 		{
@@ -243,7 +242,6 @@ Type:                                 users
 | Tags.2                               | us-east                                                                     |
 | Triple Nested.Level1.Level2.Key      | hello                                                                       |
 | Triple Nested.Level1.Level2.Value    | world                                                                       |
-| Type                                 | users                                                                       |
 
 `,
 		},


### PR DESCRIPTION
Before:

```
$ tfctl api /workspaces/{workspace_id}/current-state-version-outputs -p'workspace_id=outputs'
ERROR: template: cli:1: bad character U+0022 '"'
```

After:
<img width="1227" height="358" alt="Screenshot 2026-05-22 at 10 30 38" src="https://github.com/user-attachments/assets/e2653536-d05e-49e4-906e-5ce89fbfab01" />

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
