### PR TITLE
Enable retry for rate-limited and server error responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/cli v1.1.7
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-tfe v1.78.1-0.20260603210239-533755d8b9f5
+	github.com/hashicorp/go-tfe v1.78.1-0.20260608224359-24b3bab9762b
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/itchyny/gojq v0.12.19

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-tfe v1.78.1-0.20260603210239-533755d8b9f5 h1:7o2qHEl+CYGLAfuoQdUpAO7vqCPGm4MfvJrRgSdjxW0=
-github.com/hashicorp/go-tfe v1.78.1-0.20260603210239-533755d8b9f5/go.mod h1:4ftCB91+6mLQRisgEPVFIfBvlwrFYKylgXtY3O+Ha+Y=
+github.com/hashicorp/go-tfe v1.78.1-0.20260608224359-24b3bab9762b h1:wJFf+sjjJkz8SP9FaauRVzb9Oejh2++UOhQgPTyZ8Zc=
+github.com/hashicorp/go-tfe v1.78.1-0.20260608224359-24b3bab9762b/go.mod h1:4ftCB91+6mLQRisgEPVFIfBvlwrFYKylgXtY3O+Ha+Y=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -344,7 +344,7 @@ func resolveOrg(ctx *cmd.Context, cloudCfg *terraformcfg.CloudConfig) string {
 func lookupResource(goCtx context.Context, resolver *client.Resolver, segment, org, name string) (string, error) {
 	id, err := resolver.ResolveFromName(goCtx, segment, org, name)
 	if err != nil {
-		if errors.Is(err, tfe.ErrNotFound) || isNotFound(err) {
+		if errors.Is(err, tfe.ErrNotFound) {
 			return "", fmt.Errorf("%s named %q not found in organization %q", segment, name, org)
 		}
 
@@ -354,15 +354,6 @@ func lookupResource(goCtx context.Context, resolver *client.Resolver, segment, o
 		return "", fmt.Errorf("%s %q resolved to nil ID", segment, name)
 	}
 	return *id, nil
-}
-
-// isNotFound checks whether an error from the Kiota SDK indicates a 404 response.
-func isNotFound(err error) bool {
-	var apiErr interface{ GetStatusCode() int }
-	if errors.As(err, &apiErr) {
-		return apiErr.GetStatusCode() == http.StatusNotFound
-	}
-	return false
 }
 
 func runAPI(opts *Opts) error {

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -344,7 +344,7 @@ func resolveOrg(ctx *cmd.Context, cloudCfg *terraformcfg.CloudConfig) string {
 func lookupResource(goCtx context.Context, resolver *client.Resolver, segment, org, name string) (string, error) {
 	id, err := resolver.ResolveFromName(goCtx, segment, org, name)
 	if err != nil {
-		if errors.Is(err, tfe.ErrNotFound) {
+		if errors.Is(err, tfe.ErrNotFound) || isNotFound(err) {
 			return "", fmt.Errorf("%s named %q not found in organization %q", segment, name, org)
 		}
 
@@ -354,6 +354,15 @@ func lookupResource(goCtx context.Context, resolver *client.Resolver, segment, o
 		return "", fmt.Errorf("%s %q resolved to nil ID", segment, name)
 	}
 	return *id, nil
+}
+
+// isNotFound checks whether an error from the Kiota SDK indicates a 404 response.
+func isNotFound(err error) bool {
+	var apiErr interface{ GetStatusCode() int }
+	if errors.As(err, &apiErr) {
+		return apiErr.GetStatusCode() == http.StatusNotFound
+	}
+	return false
 }
 
 func runAPI(opts *Opts) error {

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -745,7 +745,7 @@ func newTestOpts(t *testing.T, address string, io *iostreams.Testing, mutate fun
 	t.Helper()
 	apiClient, err := client.New(address, "test-token", http.Header{
 		"User-Agent": []string{"tfctl-cli/test"},
-	}, nil)
+	}, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	opts := &Opts{
@@ -832,7 +832,7 @@ func TestLookupResource_ErrNotFound(t *testing.T) {
 	})
 	defer server.Close()
 
-	apiClient, err := client.New(server.URL, "test-token", http.Header{}, nil)
+	apiClient, err := client.New(server.URL, "test-token", http.Header{}, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	resolver := client.NewResolver(apiClient, false, false)

--- a/internal/commands/api/api_test.go
+++ b/internal/commands/api/api_test.go
@@ -745,7 +745,7 @@ func newTestOpts(t *testing.T, address string, io *iostreams.Testing, mutate fun
 	t.Helper()
 	apiClient, err := client.New(address, "test-token", http.Header{
 		"User-Agent": []string{"tfctl-cli/test"},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	opts := &Opts{
@@ -832,7 +832,7 @@ func TestLookupResource_ErrNotFound(t *testing.T) {
 	})
 	defer server.Close()
 
-	apiClient, err := client.New(server.URL, "test-token", http.Header{})
+	apiClient, err := client.New(server.URL, "test-token", http.Header{}, nil)
 	require.NoError(t, err)
 
 	resolver := client.NewResolver(apiClient, false, false)

--- a/internal/commands/auth/status_test.go
+++ b/internal/commands/auth/status_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
@@ -95,7 +96,7 @@ func newFakeStatusTFE(t *testing.T, username, tokenType, tokenID, expiredAt stri
 // newStatusClient returns a *client.Client pointed at srv, for use in StatusOpts.
 func newStatusClient(t *testing.T, srv *httptest.Server) *client.Client {
 	t.Helper()
-	c, err := client.New(srv.URL, "test-token", nil, nil)
+	c, err := client.New(srv.URL, "test-token", nil, hclog.NewNullLogger())
 	require.NoError(t, err)
 	return c
 }

--- a/internal/commands/auth/status_test.go
+++ b/internal/commands/auth/status_test.go
@@ -95,7 +95,7 @@ func newFakeStatusTFE(t *testing.T, username, tokenType, tokenID, expiredAt stri
 // newStatusClient returns a *client.Client pointed at srv, for use in StatusOpts.
 func newStatusClient(t *testing.T, srv *httptest.Server) *client.Client {
 	t.Helper()
-	c, err := client.New(srv.URL, "test-token", nil)
+	c, err := client.New(srv.URL, "test-token", nil, nil)
 	require.NoError(t, err)
 	return c
 }

--- a/internal/commands/auth/status_test.go
+++ b/internal/commands/auth/status_test.go
@@ -10,9 +10,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"

--- a/internal/commands/run/run_status_test.go
+++ b/internal/commands/run/run_status_test.go
@@ -41,7 +41,7 @@ func testAPI(t *testing.T, handler http.Handler) *client.Client {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
-	c, err := client.New(server.URL, "test-token", nil)
+	c, err := client.New(server.URL, "test-token", nil, nil)
 	require.NoError(t, err)
 	return c
 }

--- a/internal/commands/run/run_status_test.go
+++ b/internal/commands/run/run_status_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
@@ -41,7 +42,7 @@ func testAPI(t *testing.T, handler http.Handler) *client.Client {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
-	c, err := client.New(server.URL, "test-token", nil, nil)
+	c, err := client.New(server.URL, "test-token", nil, hclog.NewNullLogger())
 	require.NoError(t, err)
 	return c
 }

--- a/internal/commands/run/run_status_test.go
+++ b/internal/commands/run/run_status_test.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/client"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"

--- a/internal/commands/variable/variable_import_test.go
+++ b/internal/commands/variable/variable_import_test.go
@@ -327,7 +327,7 @@ func newImportTestOpts(t *testing.T, address string, io *iostreams.Testing, muta
 	t.Helper()
 	apiClient, err := client.New(address, "test-token", http.Header{
 		"User-Agent": []string{"tfctl-cli/test"},
-	}, nil)
+	}, hclog.NewNullLogger())
 	require.NoError(t, err)
 
 	opts := &ImportOpts{

--- a/internal/commands/variable/variable_import_test.go
+++ b/internal/commands/variable/variable_import_test.go
@@ -327,7 +327,7 @@ func newImportTestOpts(t *testing.T, address string, io *iostreams.Testing, muta
 	t.Helper()
 	apiClient, err := client.New(address, "test-token", http.Header{
 		"User-Agent": []string{"tfctl-cli/test"},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	opts := &ImportOpts{

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -44,12 +44,25 @@ type Request struct {
 }
 
 // New constructs a configured API client from an API address and token.
-func New(address, token string, defaultHeaders http.Header) (*Client, error) {
-	tfeClient, err := tfe.NewClient(&tfe.Config{
-		Address: address,
-		Token:   token,
-		Headers: defaultHeaders,
-	})
+// If logger is non-nil, retry attempts are logged at debug level.
+func New(address, token string, defaultHeaders http.Header, logger hclog.Logger) (*Client, error) {
+	cfg := &tfe.Config{
+		Address:           address,
+		Token:             token,
+		Headers:           defaultHeaders,
+		RetryServerErrors: true,
+		RetryRateLimited:  true,
+	}
+	if logger != nil {
+		cfg.RetryHook = func(attemptNum int, resp *http.Response) {
+			status := 0
+			if resp != nil {
+				status = resp.StatusCode
+			}
+			logger.Debug("retrying API request", "attempt", attemptNum, "status", status)
+		}
+	}
+	tfeClient, err := tfe.NewClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -52,6 +52,7 @@ func New(address, token string, defaultHeaders http.Header, logger hclog.Logger)
 		Headers:           defaultHeaders,
 		RetryServerErrors: true,
 		RetryRateLimited:  true,
+		RetryMaxRetries:   5,
 	}
 	if logger != nil {
 		cfg.RetryHook = func(attemptNum int, resp *http.Response) {

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -123,6 +123,12 @@ func (c *Client) Do(ctx context.Context, req *Request) (*http.Response, error) {
 		return nil, err
 	}
 
+	if httpResp.StatusCode >= 400 {
+		if apiErr := tfe.APIErrorFactory(httpResp, nil); apiErr != nil {
+			return nil, apiErr
+		}
+	}
+
 	return httpResp, nil
 }
 

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -57,10 +57,16 @@ func New(address, token string, defaultHeaders http.Header, logger hclog.Logger)
 	if logger != nil {
 		cfg.RetryHook = func(attemptNum int, resp *http.Response) {
 			status := 0
+			url := ""
+			method := ""
 			if resp != nil {
 				status = resp.StatusCode
+				if resp.Request != nil {
+					url = resp.Request.URL.String()
+					method = resp.Request.Method
+				}
 			}
-			logger.Debug("retrying API request", "attempt", attemptNum, "status", status)
+			logger.Debug("Retrying API request", "attempt", attemptNum, "status", status, "method", method, "url", url)
 		}
 	}
 	tfeClient, err := tfe.NewClient(cfg)

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -54,20 +54,18 @@ func New(address, token string, defaultHeaders http.Header, logger hclog.Logger)
 		RetryRateLimited:  true,
 		RetryMaxRetries:   5,
 	}
-	if logger != nil {
-		cfg.RetryHook = func(attemptNum int, resp *http.Response) {
-			status := 0
-			url := ""
-			method := ""
-			if resp != nil {
-				status = resp.StatusCode
-				if resp.Request != nil {
-					url = resp.Request.URL.String()
-					method = resp.Request.Method
-				}
+	cfg.RetryHook = func(attemptNum int, resp *http.Response) {
+		status := 0
+		url := ""
+		method := ""
+		if resp != nil {
+			status = resp.StatusCode
+			if resp.Request != nil {
+				url = resp.Request.URL.String()
+				method = resp.Request.Method
 			}
-			logger.Debug("Retrying API request", "attempt", attemptNum, "status", status, "method", method, "url", url)
 		}
+		logger.Debug("Retrying API request", "attempt", attemptNum, "status", status, "method", method, "url", url)
 	}
 	tfeClient, err := tfe.NewClient(cfg)
 	if err != nil {

--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -128,9 +128,7 @@ func (c *Client) Do(ctx context.Context, req *Request) (*http.Response, error) {
 	}
 
 	if httpResp.StatusCode >= 400 {
-		if apiErr := tfe.APIErrorFactory(httpResp, nil); apiErr != nil {
-			return nil, apiErr
-		}
+		return nil, tfe.APIErrorFactory(httpResp, nil)
 	}
 
 	return httpResp, nil

--- a/internal/pkg/client/retry_test.go
+++ b/internal/pkg/client/retry_test.go
@@ -98,3 +98,30 @@ func TestRetryLogHook(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.GreaterOrEqual(t, atomic.LoadInt64(&attempts), int64(2))
 }
+
+// TestRetryInternalServerError verifies that 500 responses are retried.
+func TestRetryInternalServerError(t *testing.T) {
+	t.Parallel()
+
+	var attempts int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&attempts, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := New(srv.URL, "test-token", nil, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	resp, err := c.TFE.GetStream(t.Context(), "/test", nil)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, atomic.LoadInt64(&attempts), int64(3))
+}

--- a/internal/pkg/client/retry_test.go
+++ b/internal/pkg/client/retry_test.go
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetryServerErrors verifies that 5xx responses are retried when
+// RetryServerErrors is enabled in the tfe.Config.
+func TestRetryServerErrors(t *testing.T) {
+	t.Parallel()
+
+	var attempts int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&attempts, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := New(srv.URL, "test-token", nil, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	resp, err := c.TFE.GetStream(t.Context(), "/test", nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	got := atomic.LoadInt64(&attempts)
+	if got < 3 {
+		t.Skipf("retries not working yet (got %d attempts, want >=3); pending go-tfe middleware fix", got)
+	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestRetryRateLimited verifies that 429 responses are retried when
+// RetryRateLimited is enabled in the tfe.Config.
+func TestRetryRateLimited(t *testing.T) {
+	t.Parallel()
+
+	var attempts int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&attempts, 1)
+		if n < 3 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := New(srv.URL, "test-token", nil, hclog.NewNullLogger())
+	require.NoError(t, err)
+
+	resp, err := c.TFE.GetStream(t.Context(), "/test", nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	got := atomic.LoadInt64(&attempts)
+	if got < 3 {
+		t.Skipf("retries not working yet (got %d attempts, want >=3); pending go-tfe middleware fix", got)
+	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestRetryLogHook verifies that the RetryHook is invoked on each retry,
+// producing debug-level log output.
+func TestRetryLogHook(t *testing.T) {
+	t.Parallel()
+
+	var attempts int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&attempts, 1)
+		if n < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := hclog.New(&hclog.LoggerOptions{Level: hclog.Debug})
+	c, err := New(srv.URL, "test-token", nil, logger)
+	require.NoError(t, err)
+
+	resp, err := c.TFE.GetStream(t.Context(), "/test", nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	got := atomic.LoadInt64(&attempts)
+	if got < 2 {
+		t.Skipf("retries not working yet (got %d attempts, want >=2); pending go-tfe middleware fix", got)
+	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/internal/pkg/client/retry_test.go
+++ b/internal/pkg/client/retry_test.go
@@ -34,16 +34,11 @@ func TestRetryServerErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := c.TFE.GetStream(t.Context(), "/test", nil)
-	if resp != nil {
-		resp.Body.Close()
-	}
-
-	got := atomic.LoadInt64(&attempts)
-	if got < 3 {
-		t.Skipf("retries not working yet (got %d attempts, want >=3); pending go-tfe middleware fix", got)
-	}
 	require.NoError(t, err)
+	resp.Body.Close()
+
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, atomic.LoadInt64(&attempts), int64(3))
 }
 
 // TestRetryRateLimited verifies that 429 responses are retried when
@@ -68,16 +63,11 @@ func TestRetryRateLimited(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := c.TFE.GetStream(t.Context(), "/test", nil)
-	if resp != nil {
-		resp.Body.Close()
-	}
-
-	got := atomic.LoadInt64(&attempts)
-	if got < 3 {
-		t.Skipf("retries not working yet (got %d attempts, want >=3); pending go-tfe middleware fix", got)
-	}
 	require.NoError(t, err)
+	resp.Body.Close()
+
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, atomic.LoadInt64(&attempts), int64(3))
 }
 
 // TestRetryLogHook verifies that the RetryHook is invoked on each retry,
@@ -102,14 +92,9 @@ func TestRetryLogHook(t *testing.T) {
 	require.NoError(t, err)
 
 	resp, err := c.TFE.GetStream(t.Context(), "/test", nil)
-	if resp != nil {
-		resp.Body.Close()
-	}
-
-	got := atomic.LoadInt64(&attempts)
-	if got < 2 {
-		t.Skipf("retries not working yet (got %d attempts, want >=2); pending go-tfe middleware fix", got)
-	}
 	require.NoError(t, err)
+	resp.Body.Close()
+
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, atomic.LoadInt64(&attempts), int64(2))
 }

--- a/internal/pkg/client/run_summary_test.go
+++ b/internal/pkg/client/run_summary_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 func TestParseDiagnostics_Structured(t *testing.T) {
@@ -179,7 +181,7 @@ func Test_PopulatePolicyCheckSummary(t *testing.T) {
 	}))
 	t.Cleanup(api.Close)
 
-	c, err := New(api.URL, "test-token", nil, nil)
+	c, err := New(api.URL, "test-token", nil, hclog.NewNullLogger())
 	if err != nil {
 		t.Fatalf("creating client: %v", err)
 	}

--- a/internal/pkg/client/run_summary_test.go
+++ b/internal/pkg/client/run_summary_test.go
@@ -179,7 +179,7 @@ func Test_PopulatePolicyCheckSummary(t *testing.T) {
 	}))
 	t.Cleanup(api.Close)
 
-	c, err := New(api.URL, "test-token", nil)
+	c, err := New(api.URL, "test-token", nil, nil)
 	if err != nil {
 		t.Fatalf("creating client: %v", err)
 	}

--- a/internal/pkg/cmd/context.go
+++ b/internal/pkg/cmd/context.go
@@ -261,7 +261,7 @@ func (ctx *Context) NewAPIClient(logger hclog.Logger) (*client.Client, error) {
 	}
 	apiClient, err := client.New(address, ctx.Profile.GetToken(), http.Header{
 		"User-Agent": []string{fmt.Sprintf("%s-cli/%s", version.Name, version.Version)},
-	})
+	}, logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
Configures the `go-tfe` client to automatically retry on 429 (rate limited) and 5xx (server error) responses, up to 5 times
### Changes
- `client.New()` accepts a logger and enables retry for rate-limited and server error responses
- Logs each retry attempt at debug level so retries are visible in `--debug` output
- Converts error HTTP responses to structured errors in `Do()` (previously handled by go-tfe middleware)
- Handles 404s from the Kiota SDK path in resource lookups
- Adds smoke tests verifying retry behavior for 503, 429, and log output
- Bumps go-tfe to include the middleware ordering fix 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
