### PR TITLE
Fix eval graders and bump tool call limits

### DIFF
--- a/evals/tfctl-evals/.github/workflows/eval.yml
+++ b/evals/tfctl-evals/.github/workflows/eval.yml
@@ -1,0 +1,55 @@
+name: Skill Evals
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model to evaluate against"
+        required: true
+        default: "claude-sonnet-4.6"
+        type: choice
+        options:
+          - claude-sonnet-4.6
+          - claude-opus-4.6
+          - gpt-4.1
+          - gpt-5.2
+      tasks:
+        description: "Task filter glob (blank = all)"
+        required: false
+        type: string
+      tags:
+        description: "Tag filter (blank = all)"
+        required: false
+        type: string
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install waza
+        run: curl -fsSL https://raw.githubusercontent.com/microsoft/waza/main/install.sh | bash
+
+      - name: Run evals
+        working-directory: evals/tfctl-evals
+        env:
+          # Uses the Actions-provided GITHUB_TOKEN if org has Copilot enabled.
+          # Falls back to COPILOT_TOKEN secret if that doesn't work.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_TOKEN || github.token }}
+        run: |
+          ARGS="--model ${{ inputs.model }}"
+          if [ -n "${{ inputs.tasks }}" ]; then
+            ARGS="$ARGS --task '${{ inputs.tasks }}'"
+          fi
+          if [ -n "${{ inputs.tags }}" ]; then
+            ARGS="$ARGS --tags '${{ inputs.tags }}'"
+          fi
+          eval waza run evals/tfctl/eval.yaml $ARGS -o results.json
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ inputs.model }}
+          path: evals/tfctl-evals/results.json

--- a/evals/tfctl-evals/evals/tfctl/eval.yaml
+++ b/evals/tfctl-evals/evals/tfctl/eval.yaml
@@ -48,7 +48,7 @@ graders:
     name: max_efficiency
     weight: 1.0
     config:
-      max_tool_calls: 10
+      max_tool_calls: 40
 
 
 tasks:

--- a/evals/tfctl-evals/evals/tfctl/tasks/00-list-workspaces-pagination.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/00-list-workspaces-pagination.yaml
@@ -18,4 +18,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/01-find-workspace-partial-name.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/01-find-workspace-partial-name.yaml
@@ -19,4 +19,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/02-list-workspace-variables.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/02-list-workspace-variables.yaml
@@ -10,7 +10,7 @@ inputs:
   prompt: |
     List all variables in the 'billing-prod' workspace in the tfc-demo-au organization,
     showing their keys, categories (env vs terraform), and whether they're sensitive.
-    Use the correct API endpoint.
+    Use tfctl with the -p workspace= flag for the workspace parameter.
 
 expected:
   output_contains:
@@ -21,4 +21,4 @@ expected:
     - "/organizations/tfc-demo-au/workspaces/billing-prod/vars"
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/03-refuse-delete.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/03-refuse-delete.yaml
@@ -24,4 +24,4 @@ expected:
   output_contains:
     - "DELETE"
   behavior:
-    max_tool_calls: 1
+    max_tool_calls: 5

--- a/evals/tfctl-evals/evals/tfctl/tasks/04-no-external-jq.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/04-no-external-jq.yaml
@@ -17,6 +17,5 @@ expected:
   output_not_contains:
     - "| jq"
     - "|jq"
-    - "pipe"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/05-get-current-run-status.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/05-get-current-run-status.yaml
@@ -19,4 +19,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 4
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/06-count-by-tf-version.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/06-count-by-tf-version.yaml
@@ -18,4 +18,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/07-list-vars-sensitive-filter.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/07-list-vars-sensitive-filter.yaml
@@ -20,4 +20,4 @@ expected:
     - "/organizations/tfc-demo-au/workspaces/api-prod/vars"
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/08-find-workspace-by-vcs.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/08-find-workspace-by-vcs.yaml
@@ -21,4 +21,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/09-get-run-logs-completed.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/09-get-run-logs-completed.yaml
@@ -18,4 +18,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/10-create-update-variable.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/10-create-update-variable.yaml
@@ -20,4 +20,4 @@ expected:
     - "/organizations/tfc-demo-au/workspaces/dev-env/vars"
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/11-list-remote-state-consumers.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/11-list-remote-state-consumers.yaml
@@ -18,4 +18,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/12-add-remote-state-consumer.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/12-add-remote-state-consumer.yaml
@@ -21,4 +21,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 5
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/13-list-variable-sets.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/13-list-variable-sets.yaml
@@ -20,4 +20,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/14-apply-variable-set.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/14-apply-variable-set.yaml
@@ -21,4 +21,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 5
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/15-get-state-version.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/15-get-state-version.yaml
@@ -17,4 +17,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/16-stop-when-org-not-found.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/16-stop-when-org-not-found.yaml
@@ -22,4 +22,4 @@ expected:
     - "exit 2"
     - "enterprise"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/17-diagnose-failed-run.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/17-diagnose-failed-run.yaml
@@ -20,4 +20,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/18-list-workspaces-by-team.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/18-list-workspaces-by-team.yaml
@@ -18,4 +18,4 @@ expected:
     - "/organizations/tfc-demo-au/teams/bu1_admin/workspaces"
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/19-get-org-settings.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/19-get-org-settings.yaml
@@ -17,4 +17,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/20-workspace-not-found-stop.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/20-workspace-not-found-stop.yaml
@@ -20,4 +20,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 1
+    max_tool_calls: 5

--- a/evals/tfctl-evals/evals/tfctl/tasks/21-list-runs-status-filter.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/21-list-runs-status-filter.yaml
@@ -20,4 +20,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/22-get-policy-checks.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/22-get-policy-checks.yaml
@@ -18,4 +18,4 @@ expected:
     - "/workspaces/"
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/23-list-notifications.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/23-list-notifications.yaml
@@ -17,4 +17,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/24-search-api-operations.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/24-search-api-operations.yaml
@@ -19,4 +19,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/25-handle-auth-expiry.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/25-handle-auth-expiry.yaml
@@ -21,4 +21,4 @@ expected:
     - "retry indefinitely"
     - "| jq"
   behavior:
-    max_tool_calls: 3
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/26-get-config-version.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/26-get-config-version.yaml
@@ -18,4 +18,4 @@ expected:
     - "/organizations/tfc-demo-au/workspaces/network-infra/configuration-versions"
     - "| jq"
   behavior:
-    max_tool_calls: 2
+    max_tool_calls: 10

--- a/evals/tfctl-evals/evals/tfctl/tasks/27-batch-update-variables.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/27-batch-update-variables.yaml
@@ -18,4 +18,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 5
+    max_tool_calls: 15

--- a/evals/tfctl-evals/evals/tfctl/tasks/28-unknown-workspace-id.yaml
+++ b/evals/tfctl-evals/evals/tfctl/tasks/28-unknown-workspace-id.yaml
@@ -21,4 +21,4 @@ expected:
   output_not_contains:
     - "| jq"
   behavior:
-    max_tool_calls: 1
+    max_tool_calls: 5


### PR DESCRIPTION
## Description
Some more evals changes:
- Add GitHub Actions workflow (manual dispatch with model selection)
- Switch `no_external_jq` to `tool_constraint` grader 
- Add global graders: no_raw_http, no_terraform_destroy, max_efficiency
- Remove skill_invocation grader (false positives on refusal/negative tasks)
- Bump per-task max_tool_calls to realistic limits (5/10/15 tiers) because copilot-sdk counts turns as tool calls
- Bump global ceiling to 40
- Fix task 02 prompt to explicitly hint -p workspace= flag
- Fix task 04: remove overly broad "pipe" from `output_not_contains`
- Symlink skills/SKILL.md to source so evals always test the latest version
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

## The Three Ex's:

### External Links

- [JIRA](https://hashicorp.atlassian.net/browse/xxxx)

### Example Output

<!--
One easy way to create a screenshot is:
go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -- tfctl mycommand --myflag
-->

### Extra Things that are Easy to Forget

- [ ] If you added a top level command or global flag, run `make gen/screenshot` to update the README screenshot
- [ ] Think through bash autocomplete prediction for new command targets or flag argument values
