### PR TITLE
Fix -race failures from package-level test seams in api and auth

### DIFF
--- a/internal/commands/api/schema.go
+++ b/internal/commands/api/schema.go
@@ -53,6 +53,37 @@ func defaultSchemaLoader(ctx *cmd.Context, c *cmd.Command) func() openapi.Schema
 	}
 }
 
+// schemaCmdConfig holds optional, construction-time overrides for the schema
+// subcommands. It lets tests drive the full command.Run path (flag parsing,
+// arg-count validation, exit-code mapping, IO wiring) with an injected loader
+// instead of mutating package-level state, keeping parallel tests race-free.
+type schemaCmdConfig struct {
+	// loadSchema, when non-nil, overrides the production schema loader. When
+	// nil, the command builds defaultSchemaLoader at run time.
+	loadSchema func() openapi.Schema
+	searcher   schemaSearcher
+}
+
+// schemaCmdOption customizes a schema subcommand at construction time.
+type schemaCmdOption func(*schemaCmdConfig)
+
+// newSchemaCmdConfig applies the given options over the production defaults.
+func newSchemaCmdConfig(opts ...schemaCmdOption) schemaCmdConfig {
+	cfg := schemaCmdConfig{searcher: schemaOperationSearcher}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// withSchemaLoader overrides the schema loader, primarily for tests that want
+// to exercise the full command.Run path against a fixture schema.
+func withSchemaLoader(load func() openapi.Schema) schemaCmdOption {
+	return func(cfg *schemaCmdConfig) {
+		cfg.loadSchema = load
+	}
+}
+
 // NewCmdAPISchema creates the api schema command group.
 func NewCmdAPISchema(ctx *cmd.Context) *cmd.Command {
 	c := &cmd.Command{
@@ -71,7 +102,8 @@ func NewCmdAPISchema(ctx *cmd.Context) *cmd.Command {
 	return c
 }
 
-func newCmdAPISchemaSearch(ctx *cmd.Context) *cmd.Command {
+func newCmdAPISchemaSearch(ctx *cmd.Context, opts ...schemaCmdOption) *cmd.Command {
+	cfg := newSchemaCmdConfig(opts...)
 	return &cmd.Command{
 		Name:           "search",
 		ShortHelp:      "Search API operations",
@@ -91,12 +123,16 @@ func newCmdAPISchemaSearch(ctx *cmd.Context) *cmd.Command {
 			Command:  fmt.Sprintf("$ %s api schema search workspace", version.Name),
 		}},
 		RunF: func(c *cmd.Command, args []string) error {
+			load := cfg.loadSchema
+			if load == nil {
+				load = defaultSchemaLoader(ctx, c)
+			}
 			return runSchemaSearch(schemaSearchOpts{
 				IO:          ctx.IO,
 				Output:      ctx.Output,
 				ShutdownCtx: ctx.ShutdownCtx,
-				LoadSchema:  defaultSchemaLoader(ctx, c),
-				Searcher:    schemaOperationSearcher,
+				LoadSchema:  load,
+				Searcher:    cfg.searcher,
 				Query:       strings.Join(args, " "),
 			})
 		},
@@ -160,7 +196,8 @@ func (d SchemaSearchResultsDisplayer) FieldTemplates() []format.Field {
 	}
 }
 
-func newCmdAPISchemaGet(ctx *cmd.Context) *cmd.Command {
+func newCmdAPISchemaGet(ctx *cmd.Context, opts ...schemaCmdOption) *cmd.Command {
+	cfg := newSchemaCmdConfig(opts...)
 	return &cmd.Command{
 		Name:           "get",
 		ShortHelp:      "Show API operation schema by operation ID or path",
@@ -185,9 +222,13 @@ func newCmdAPISchemaGet(ctx *cmd.Context) *cmd.Command {
 			},
 		},
 		RunF: func(c *cmd.Command, args []string) error {
+			load := cfg.loadSchema
+			if load == nil {
+				load = defaultSchemaLoader(ctx, c)
+			}
 			return runSchemaGet(schemaGetOpts{
 				IO:         ctx.IO,
-				LoadSchema: defaultSchemaLoader(ctx, c),
+				LoadSchema: load,
 				Target:     args[0],
 			})
 		},

--- a/internal/commands/api/schema.go
+++ b/internal/commands/api/schema.go
@@ -61,7 +61,6 @@ type schemaCmdConfig struct {
 	// loadSchema, when non-nil, overrides the production schema loader. When
 	// nil, the command builds defaultSchemaLoader at run time.
 	loadSchema func() openapi.Schema
-	searcher   schemaSearcher
 }
 
 // schemaCmdOption customizes a schema subcommand at construction time.
@@ -69,7 +68,7 @@ type schemaCmdOption func(*schemaCmdConfig)
 
 // newSchemaCmdConfig applies the given options over the production defaults.
 func newSchemaCmdConfig(opts ...schemaCmdOption) schemaCmdConfig {
-	cfg := schemaCmdConfig{searcher: schemaOperationSearcher}
+	cfg := schemaCmdConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -132,7 +131,7 @@ func newCmdAPISchemaSearch(ctx *cmd.Context, opts ...schemaCmdOption) *cmd.Comma
 				Output:      ctx.Output,
 				ShutdownCtx: ctx.ShutdownCtx,
 				LoadSchema:  load,
-				Searcher:    cfg.searcher,
+				Searcher:    schemaOperationSearcher,
 				Query:       strings.Join(args, " "),
 			})
 		},

--- a/internal/commands/api/schema.go
+++ b/internal/commands/api/schema.go
@@ -8,25 +8,50 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/heredoc"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/openapi"
 	"github.com/hashicorp/tfctl-cli/version"
 )
-
-type schemaOperationsLoader func(ctx *cmd.Context, logger hclog.Logger) openapi.Schema
 
 type schemaSearcher interface {
 	Search(ctx context.Context, query string, operations []*openapi.Operation, limit int) ([]schemaSearchResult, error)
 }
 
-var (
-	loadSchemaOperationsForSchemaCommand schemaOperationsLoader = openapi.SchemaFactory
-	schemaOperationSearcher              schemaSearcher         = hybridSchemaSearcher{}
-)
+// schemaOperationSearcher is the default searcher used by the schema commands.
+// It is stateless and only ever read, so it is safe to share across commands.
+var schemaOperationSearcher schemaSearcher = hybridSchemaSearcher{}
+
+// schemaSearchOpts carries the dependencies and parsed inputs for the
+// `api schema search` command so that runSchemaSearch can be tested in
+// isolation without mutating any package-level state.
+type schemaSearchOpts struct {
+	IO          iostreams.IOStreams
+	Output      *format.Outputter
+	ShutdownCtx context.Context
+	LoadSchema  func() openapi.Schema
+	Searcher    schemaSearcher
+	Query       string
+}
+
+// schemaGetOpts carries the dependencies and parsed inputs for the
+// `api schema get` command so that runSchemaGet can be tested in isolation
+// without mutating any package-level state.
+type schemaGetOpts struct {
+	IO         iostreams.IOStreams
+	LoadSchema func() openapi.Schema
+	Target     string
+}
+
+// defaultSchemaLoader binds the command context and logger into a loader
+// closure that fetches the OpenAPI schema via the production SchemaFactory.
+func defaultSchemaLoader(ctx *cmd.Context, c *cmd.Command) func() openapi.Schema {
+	return func() openapi.Schema {
+		return openapi.SchemaFactory(ctx, c.Logger(ctx))
+	}
+}
 
 // NewCmdAPISchema creates the api schema command group.
 func NewCmdAPISchema(ctx *cmd.Context) *cmd.Command {
@@ -66,22 +91,33 @@ func newCmdAPISchemaSearch(ctx *cmd.Context) *cmd.Command {
 			Command:  fmt.Sprintf("$ %s api schema search workspace", version.Name),
 		}},
 		RunF: func(c *cmd.Command, args []string) error {
-			query := strings.Join(args, " ")
-			schema := loadSchemaOperationsForSchemaCommand(ctx, c.Logger(ctx))
-
-			results, err := schemaOperationSearcher.Search(ctx.ShutdownCtx, query, schema.Operations(), maxSchemaSearchResults)
-			if err != nil {
-				return err
-			}
-			if len(results) == 0 {
-				return fmt.Errorf("%s No API operations matched %q", ctx.IO.ColorScheme().FailureIcon(), query)
-			}
-
-			return ctx.Output.Display(SchemaSearchResultsDisplayer{
-				results: results,
+			return runSchemaSearch(schemaSearchOpts{
+				IO:          ctx.IO,
+				Output:      ctx.Output,
+				ShutdownCtx: ctx.ShutdownCtx,
+				LoadSchema:  defaultSchemaLoader(ctx, c),
+				Searcher:    schemaOperationSearcher,
+				Query:       strings.Join(args, " "),
 			})
 		},
 	}
+}
+
+// runSchemaSearch searches the loaded schema operations and renders the results.
+func runSchemaSearch(opts schemaSearchOpts) error {
+	schema := opts.LoadSchema()
+
+	results, err := opts.Searcher.Search(opts.ShutdownCtx, opts.Query, schema.Operations(), maxSchemaSearchResults)
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		return fmt.Errorf("%s No API operations matched %q", opts.IO.ColorScheme().FailureIcon(), opts.Query)
+	}
+
+	return opts.Output.Display(SchemaSearchResultsDisplayer{
+		results: results,
+	})
 }
 
 // SchemaSearchResultsDisplayer is the displayer for schema search results.
@@ -149,26 +185,36 @@ func newCmdAPISchemaGet(ctx *cmd.Context) *cmd.Command {
 			},
 		},
 		RunF: func(c *cmd.Command, args []string) error {
-			schema := loadSchemaOperationsForSchemaCommand(ctx, c.Logger(ctx))
-
-			var err error
-			var result openapi.Schema
-			if strings.HasPrefix(args[0], "/") {
-				result, err = schema.AtomizePath(args[0])
-			} else {
-				result, err = schema.AtomizeOperation(args[0])
-			}
-			if err != nil {
-				return err
-			}
-
-			body, err := result.MarshalJSON()
-			if err != nil {
-				return fmt.Errorf("failed to marshal operation schema: %w", err)
-			}
-
-			fmt.Fprintln(ctx.IO.Out(), string(body))
-			return nil
+			return runSchemaGet(schemaGetOpts{
+				IO:         ctx.IO,
+				LoadSchema: defaultSchemaLoader(ctx, c),
+				Target:     args[0],
+			})
 		},
 	}
+}
+
+// runSchemaGet renders a trimmed OpenAPI document for a single operationId or
+// all operations on an exact API path.
+func runSchemaGet(opts schemaGetOpts) error {
+	schema := opts.LoadSchema()
+
+	var err error
+	var result openapi.Schema
+	if strings.HasPrefix(opts.Target, "/") {
+		result, err = schema.AtomizePath(opts.Target)
+	} else {
+		result, err = schema.AtomizeOperation(opts.Target)
+	}
+	if err != nil {
+		return err
+	}
+
+	body, err := result.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal operation schema: %w", err)
+	}
+
+	fmt.Fprintln(opts.IO.Out(), string(body))
+	return nil
 }

--- a/internal/commands/api/schema_eval_test.go
+++ b/internal/commands/api/schema_eval_test.go
@@ -127,7 +127,7 @@ func TestSchemaSearchSummary(t *testing.T) {
 }
 
 func TestSpecBackedSchemaSearch(t *testing.T) {
-	schema := loadSchemaOperationsForSchemaCommand(testCommandContext(iostreams.Test()), hclog.NewNullLogger())
+	schema := openapi.SchemaFactory(testCommandContext(iostreams.Test()), hclog.NewNullLogger())
 	if schema == nil {
 		t.Fatal("failed to load schema")
 	}

--- a/internal/commands/api/schema_test.go
+++ b/internal/commands/api/schema_test.go
@@ -115,6 +115,96 @@ func TestCmdAPISchemaGetByPathNotFound(t *testing.T) {
 	r.Error(err)
 }
 
+// The following tests drive the full command.Run path (flag parsing, arg-count
+// validation, exit-code mapping, IO wiring) with a per-command injected loader,
+// so they exercise the RunF closures and constructor wiring while staying free
+// of any shared package state.
+
+func TestCmdAPISchemaSearchCommandRun(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	io := iostreams.Test()
+	cCtx := testCommandContext(io)
+
+	command := newCmdAPISchemaSearch(cCtx, withSchemaLoader(fixtureSchemaLoader(t)))
+	command.SetIO(io)
+
+	// Multiple args exercise strings.Join and MinimumNArgs(1) validation.
+	r.Equal(0, command.Run([]string{"cancel", "run"}, cCtx))
+
+	output := io.Output.String()
+	r.Contains(output, "getRun")
+	r.Contains(output, "/runs/{run_id}")
+	r.Empty(io.Error.String())
+}
+
+func TestCmdAPISchemaSearchCommandRequiresArg(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	io := iostreams.Test()
+	cCtx := testCommandContext(io)
+
+	command := newCmdAPISchemaSearch(cCtx, withSchemaLoader(fixtureSchemaLoader(t)))
+	command.SetIO(io)
+
+	// MinimumNArgs(1): missing QUERY must fail before RunF runs.
+	r.Equal(1, command.Run([]string{}, cCtx))
+	r.NotEmpty(io.Error.String())
+}
+
+func TestCmdAPISchemaGetCommandRun(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	io := iostreams.Test()
+	cCtx := testCommandContext(io)
+
+	command := newCmdAPISchemaGet(cCtx, withSchemaLoader(fixtureSchemaLoader(t)))
+	command.SetIO(io)
+
+	r.Equal(0, command.Run([]string{"getWorkspace"}, cCtx))
+
+	output := io.Output.String()
+	r.Contains(output, `"operationId":"getWorkspace"`)
+	r.Contains(output, `"/workspaces/{workspace_id}"`)
+	r.Empty(io.Error.String())
+}
+
+func TestCmdAPISchemaGetCommandRequiresExactlyOneArg(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	// ExactArgs(1): both too few and too many args must fail in validation,
+	// before the RunF closure indexes args[0].
+	for _, args := range [][]string{{}, {"getWorkspace", "extra"}} {
+		io := iostreams.Test()
+		cCtx := testCommandContext(io)
+
+		command := newCmdAPISchemaGet(cCtx, withSchemaLoader(fixtureSchemaLoader(t)))
+		command.SetIO(io)
+
+		r.Equal(1, command.Run(args, cCtx))
+		r.NotEmpty(io.Error.String())
+		r.Empty(io.Output.String())
+	}
+}
+
+func TestCmdAPISchemaGetCommandNotFoundExitCode(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	io := iostreams.Test()
+	cCtx := testCommandContext(io)
+
+	command := newCmdAPISchemaGet(cCtx, withSchemaLoader(fixtureSchemaLoader(t)))
+	command.SetIO(io)
+
+	// A RunF error maps to a non-zero exit code via command.Run.
+	r.Equal(1, command.Run([]string{"/nonexistent"}, cCtx))
+}
+
 // fixtureSchemaLoader returns a loader closure backed by the embedded test
 // fixture spec, suitable for injecting into schemaSearchOpts/schemaGetOpts.
 func fixtureSchemaLoader(t *testing.T) func() openapi.Schema {

--- a/internal/commands/api/schema_test.go
+++ b/internal/commands/api/schema_test.go
@@ -63,6 +63,30 @@ func TestCmdAPISchemaSearchRun(t *testing.T) {
 	r.Empty(io.Error.String())
 }
 
+func TestCmdAPISchemaSearchNoResults(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	io := iostreams.Test()
+	cCtx := testCommandContext(io)
+
+	// An injected searcher that returns no matches drives runSchemaSearch's
+	// no-results branch deterministically, without depending on the production
+	// ranking behavior.
+	err := runSchemaSearch(schemaSearchOpts{
+		IO:          io,
+		Output:      cCtx.Output,
+		ShutdownCtx: cCtx.ShutdownCtx,
+		LoadSchema:  fixtureSchemaLoader(t),
+		Searcher:    emptySchemaSearcher{},
+		Query:       "no-such-operation",
+	})
+	r.Error(err)
+	r.Contains(err.Error(), "No API operations matched")
+	r.Contains(err.Error(), "no-such-operation")
+	r.Empty(io.Output.String())
+}
+
 func TestCmdAPISchemaGetRun(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
@@ -233,4 +257,12 @@ func containsOperation(operations []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// emptySchemaSearcher is a stub schemaSearcher that always returns no matches,
+// used to exercise runSchemaSearch's no-results error branch deterministically.
+type emptySchemaSearcher struct{}
+
+func (emptySchemaSearcher) Search(context.Context, string, []*openapi.Operation, int) ([]schemaSearchResult, error) {
+	return nil, nil
 }

--- a/internal/commands/api/schema_test.go
+++ b/internal/commands/api/schema_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
@@ -47,22 +45,17 @@ func TestCmdAPISchemaSearchRun(t *testing.T) {
 	r := require.New(t)
 
 	io := iostreams.Test()
-	originalLoader := loadSchemaOperationsForSchemaCommand
-	loadSchemaOperationsForSchemaCommand = func(*cmd.Context, hclog.Logger) openapi.Schema {
-		data, err := openapi.NewFromData(embeddedFixtureSpec)
-		if err != nil {
-			t.Fatalf("failed to load test schema: %v", err)
-		}
-		return data
-	}
-	t.Cleanup(func() {
-		loadSchemaOperationsForSchemaCommand = originalLoader
-	})
-
 	cCtx := testCommandContext(io)
-	command := newCmdAPISchemaSearch(cCtx)
-	command.SetIO(io)
-	r.Equal(0, command.Run([]string{"cancel", "run"}, cCtx))
+
+	err := runSchemaSearch(schemaSearchOpts{
+		IO:          io,
+		Output:      cCtx.Output,
+		ShutdownCtx: cCtx.ShutdownCtx,
+		LoadSchema:  fixtureSchemaLoader(t),
+		Searcher:    schemaOperationSearcher,
+		Query:       "cancel run",
+	})
+	r.NoError(err)
 
 	output := io.Output.String()
 	r.Contains(output, "getRun")
@@ -75,22 +68,13 @@ func TestCmdAPISchemaGetRun(t *testing.T) {
 	r := require.New(t)
 
 	io := iostreams.Test()
-	originalLoader := loadSchemaOperationsForSchemaCommand
-	loadSchemaOperationsForSchemaCommand = func(*cmd.Context, hclog.Logger) openapi.Schema {
-		result, err := openapi.NewFromData(embeddedFixtureSpec)
-		if err != nil {
-			t.Fatalf("failed to load test schema: %v", err)
-		}
-		return result
-	}
-	t.Cleanup(func() {
-		loadSchemaOperationsForSchemaCommand = originalLoader
-	})
 
-	cCtx := testCommandContext(io)
-	command := newCmdAPISchemaGet(cCtx)
-	command.SetIO(io)
-	r.Equal(0, command.Run([]string{"getWorkspace"}, cCtx))
+	err := runSchemaGet(schemaGetOpts{
+		IO:         io,
+		LoadSchema: fixtureSchemaLoader(t),
+		Target:     "getWorkspace",
+	})
+	r.NoError(err)
 
 	output := io.Output.String()
 	r.Contains(output, `"operationId":"getWorkspace"`)
@@ -99,25 +83,17 @@ func TestCmdAPISchemaGetRun(t *testing.T) {
 }
 
 func TestCmdAPISchemaGetByPath(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	io := iostreams.Test()
-	cCtx := testCommandContext(io)
-	originalLoader := loadSchemaOperationsForSchemaCommand
-	loadSchemaOperationsForSchemaCommand = func(ctx *cmd.Context, logger hclog.Logger) openapi.Schema {
-		result, err := openapi.NewFromData(embeddedFixtureSpec)
-		if err != nil {
-			t.Fatalf("failed to load test schema: %v", err)
-		}
-		return result
-	}
-	t.Cleanup(func() {
-		loadSchemaOperationsForSchemaCommand = originalLoader
-	})
 
-	command := newCmdAPISchemaGet(cCtx)
-	command.SetIO(io)
-	r.Equal(0, command.Run([]string{"/workspaces/{workspace_id}/vars"}, cCtx))
+	err := runSchemaGet(schemaGetOpts{
+		IO:         io,
+		LoadSchema: fixtureSchemaLoader(t),
+		Target:     "/workspaces/{workspace_id}/vars",
+	})
+	r.NoError(err)
 
 	output := io.Output.String()
 	r.Contains(output, `"listWorkspaceVars"`)
@@ -126,25 +102,30 @@ func TestCmdAPISchemaGetByPath(t *testing.T) {
 }
 
 func TestCmdAPISchemaGetByPathNotFound(t *testing.T) {
+	t.Parallel()
 	r := require.New(t)
 
 	io := iostreams.Test()
-	originalLoader := loadSchemaOperationsForSchemaCommand
-	loadSchemaOperationsForSchemaCommand = func(*cmd.Context, hclog.Logger) openapi.Schema {
-		result, err := openapi.NewFromData(embeddedFixtureSpec)
+
+	err := runSchemaGet(schemaGetOpts{
+		IO:         io,
+		LoadSchema: fixtureSchemaLoader(t),
+		Target:     "/nonexistent",
+	})
+	r.Error(err)
+}
+
+// fixtureSchemaLoader returns a loader closure backed by the embedded test
+// fixture spec, suitable for injecting into schemaSearchOpts/schemaGetOpts.
+func fixtureSchemaLoader(t *testing.T) func() openapi.Schema {
+	t.Helper()
+	return func() openapi.Schema {
+		schema, err := openapi.NewFromData(embeddedFixtureSpec)
 		if err != nil {
 			t.Fatalf("failed to load test schema: %v", err)
 		}
-		return result
+		return schema
 	}
-	t.Cleanup(func() {
-		loadSchemaOperationsForSchemaCommand = originalLoader
-	})
-
-	cCtx := testCommandContext(io)
-	command := newCmdAPISchemaGet(cCtx)
-	command.SetIO(io)
-	r.Equal(1, command.Run([]string{"/nonexistent"}, cCtx))
 }
 
 func testCommandContext(io *iostreams.Testing) *cmd.Context {

--- a/internal/commands/auth/browser.go
+++ b/internal/commands/auth/browser.go
@@ -5,11 +5,8 @@ package auth
 
 import "github.com/cli/browser"
 
-// openBrowserFn is the function used to open a URL in the default browser.
-// Tests can replace this to avoid launching a real browser.
-var openBrowserFn = browser.OpenURL
-
-// openBrowser attempts to open the given URL in the default browser.
+// openBrowser attempts to open the given URL in the default browser. It is the
+// production default for LoginOpts.OpenBrowser; tests inject their own opener.
 func openBrowser(url string) error {
-	return openBrowserFn(url)
+	return browser.OpenURL(url)
 }

--- a/internal/commands/auth/login.go
+++ b/internal/commands/auth/login.go
@@ -32,10 +32,11 @@ const (
 // NewCmdLogin returns the `auth login` command for authenticating.
 func NewCmdLogin(ctx *cmd.Context) *cmd.Command {
 	opts := &LoginOpts{
-		Ctx:     ctx.ShutdownCtx,
-		IO:      ctx.IO,
-		Profile: ctx.Profile,
-		Output:  ctx.Output,
+		Ctx:         ctx.ShutdownCtx,
+		IO:          ctx.IO,
+		Profile:     ctx.Profile,
+		Output:      ctx.Output,
+		OpenBrowser: openBrowser,
 	}
 
 	cmd := &cmd.Command{
@@ -91,6 +92,11 @@ type LoginOpts struct {
 	Profile *profile.Profile
 	Output  *format.Outputter
 	Logger  hclog.Logger
+
+	// OpenBrowser opens a URL in the user's default browser. When nil, the
+	// package default openBrowser is used. Tests inject a no-op opener to avoid
+	// launching a real browser and to keep parallel tests free of shared state.
+	OpenBrowser func(url string) error
 
 	Name   string
 	Token  bool
@@ -155,7 +161,11 @@ func readTokenInteractive(opts *LoginOpts, hostname string) (string, error) {
 	fmt.Fprintf(opts.IO.Err(), "Opening browser to create a token at:\n  %s\n\n",
 		cs.String(tokenURL).Bold().String())
 
-	if err := openBrowser(tokenURL); err != nil {
+	openURL := opts.OpenBrowser
+	if openURL == nil {
+		openURL = openBrowser
+	}
+	if err := openURL(tokenURL); err != nil {
 		fmt.Fprintf(opts.IO.Err(), "%s Could not open browser. Please open the URL above manually.\n\n",
 			cs.WarningLabel())
 	}

--- a/internal/commands/auth/login_test.go
+++ b/internal/commands/auth/login_test.go
@@ -37,19 +37,17 @@ func newFakeTFE(t *testing.T, username string) *httptest.Server {
 	return srv
 }
 
-// stubBrowser replaces openBrowserFn with a no-op for the duration of the test.
-func stubBrowser(t *testing.T) {
-	t.Helper()
-	orig := openBrowserFn
-	openBrowserFn = func(url string) error { return nil }
-	t.Cleanup(func() { openBrowserFn = orig })
-}
-
 // runLogin mimics the RunF flow by creating a cmd.Context and calling loginRun.
+// It injects a no-op browser opener into the options so tests never launch a
+// real browser and never mutate shared package state (keeping them race-free
+// under t.Parallel()).
 func runLogin(t *testing.T, opts *LoginOpts) error {
 	t.Helper()
 	if opts.Logger == nil {
 		opts.Logger = hclog.NewNullLogger()
+	}
+	if opts.OpenBrowser == nil {
+		opts.OpenBrowser = func(string) error { return nil }
 	}
 	cmdCtx := &cmd.Context{
 		IO:      opts.IO,
@@ -59,7 +57,6 @@ func runLogin(t *testing.T, opts *LoginOpts) error {
 }
 
 func TestLoginFromStdin(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -89,7 +86,6 @@ func TestLoginFromStdin(t *testing.T) {
 }
 
 func TestLoginFromStdin_CustomHostname(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -114,7 +110,6 @@ func TestLoginFromStdin_CustomHostname(t *testing.T) {
 }
 
 func TestLoginFromStdin_EmptyToken(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -137,7 +132,6 @@ func TestLoginFromStdin_EmptyToken(t *testing.T) {
 }
 
 func TestLoginFromStdin_NoInput(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -159,7 +153,6 @@ func TestLoginFromStdin_NoInput(t *testing.T) {
 }
 
 func TestLoginFromStdin_WhitespaceToken(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -182,7 +175,6 @@ func TestLoginFromStdin_WhitespaceToken(t *testing.T) {
 }
 
 func TestLoginFromStdin_TokenWithWhitespace(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -209,7 +201,6 @@ func TestLoginFromStdin_TokenWithWhitespace(t *testing.T) {
 }
 
 func TestLoginInteractive_NoTTY(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -231,7 +222,6 @@ func TestLoginInteractive_NoTTY(t *testing.T) {
 }
 
 func TestLoginInteractive_Success(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -263,7 +253,6 @@ func TestLoginInteractive_Success(t *testing.T) {
 }
 
 func TestLoginFromStdin_DifferentProfile(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -302,7 +291,6 @@ func TestLoginFromStdin_DifferentProfile(t *testing.T) {
 }
 
 func TestLoginFromStdin_DryRun(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -337,7 +325,6 @@ func TestLoginFromStdin_DryRun(t *testing.T) {
 }
 
 func TestLoginInteractive_DryRun(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -373,7 +360,6 @@ func TestLoginInteractive_DryRun(t *testing.T) {
 }
 
 func TestLoginFromStdin_QuietMode(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 
@@ -402,7 +388,6 @@ func TestLoginFromStdin_QuietMode(t *testing.T) {
 }
 
 func TestLoginFromStdin_VerifyFails(t *testing.T) {
-	stubBrowser(t)
 	t.Parallel()
 	r := require.New(t)
 


### PR DESCRIPTION
## Description
`go test ./... -race` was failing. Two commands used **mutable package-level function variables as test seams**, which parallel tests reassigned while sibling parallel tests read them. This replaces both seams with dependencies injected through the command `Opts`

### Races fixed
1. **`internal/commands/api`**:`loadSchemaOperationsForSchemaCommand` (schema.go) was reassigned by `TestCmdAPISchemaSearchRun` and `TestCmdAPISchemaGetRun`, both `t.Parallel()`.
2. **`internal/commands/auth`**: `openBrowserFn` (browser.go) was reassigned by `stubBrowser`'s `t.Cleanup`, racing with parallel `TestLogin*`/`TestStatus*` reads.

### Testing
- `go test ./... -race`
- `go test ./internal/commands/api/ -race` and `./internal/commands/auth/ -race` 


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

## The Three Ex's:

### External Links

- [JIRA](https://hashicorp.atlassian.net/browse/xxxx)

### Example Output

<!--
One easy way to create a screenshot is:
go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -- tfctl mycommand --myflag
-->

### Extra Things that are Easy to Forget

- [ ] If you added a top level command or global flag, run `make gen/screenshot` to update the README screenshot
- [ ] Think through bash autocomplete prediction for new command targets or flag argument values
