### PR TITLE
Fix map, slice, and enum flags truncating values at whitespace

### DIFF
--- a/internal/pkg/flagvalue/enum.go
+++ b/internal/pkg/flagvalue/enum.go
@@ -29,7 +29,7 @@ func Enum[T comparable](allowed []T, val T, p *T) Value {
 
 func (i *enumValue[T]) Set(s string) error {
 	var v T
-	if _, err := fmt.Sscanf(s, "%v", &v); err != nil {
+	if err := setValue(&v, s); err != nil {
 		return err
 	}
 

--- a/internal/pkg/flagvalue/enum_test.go
+++ b/internal/pkg/flagvalue/enum_test.go
@@ -54,6 +54,23 @@ func TestEnum_String(t *testing.T) {
 	r.ErrorContains(err, "must be one of [trace debug info warn error]")
 }
 
+func TestEnum_StringWithSpaces(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	var choice string
+	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	f.AddFlag(&pflag.Flag{
+		Name:  "choice",
+		Value: flagvalue.Enum([]string{"Another Project", "Hello World"}, "Another Project", &choice),
+	})
+
+	// A multi-word enum value must match an allowed value verbatim rather
+	// than being truncated at the first space.
+	r.NoError(f.Parse([]string{"--choice", "Hello World"}))
+	r.Equal("Hello World", choice)
+}
+
 func TestEnum_Int(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)

--- a/internal/pkg/flagvalue/map.go
+++ b/internal/pkg/flagvalue/map.go
@@ -34,15 +34,13 @@ func (m *simpleMapValue[K, V]) Set(s string) error {
 
 	// Parse the key
 	var key K
-	_, err := fmt.Sscanf(parts[0], "%v", &key)
-	if err != nil {
+	if err := setValue(&key, parts[0]); err != nil {
 		return fmt.Errorf("failed to parse key: %w", err)
 	}
 
 	// Parse the value
 	var value V
-	_, err = fmt.Sscanf(parts[1], "%v", &value)
-	if err != nil {
+	if err := setValue(&value, parts[1]); err != nil {
 		return fmt.Errorf("failed to parse value: %w", err)
 	}
 

--- a/internal/pkg/flagvalue/map_test.go
+++ b/internal/pkg/flagvalue/map_test.go
@@ -49,6 +49,31 @@ func TestSimpleMap_StringToString(t *testing.T) {
 	}, m)
 }
 
+func TestSimpleMap_StringToStringWithSpaces(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	var m map[string]string
+	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	f.AddFlag(&pflag.Flag{
+		Name:  "values",
+		Value: flagvalue.SimpleMap[string, string](nil, &m),
+	})
+
+	// A value containing spaces must be preserved verbatim and not be
+	// truncated at the first whitespace.
+	r.NoError(f.Parse([]string{
+		"--values", "name=Another Project",
+		"--values", "key with spaces=trailing  spaces ",
+		"--values", "filter=a=b c",
+	}))
+	r.EqualValues(map[string]string{
+		"name":            "Another Project",
+		"key with spaces": "trailing  spaces ",
+		"filter":          "a=b c",
+	}, m)
+}
+
 func TestSimpleMap_StringToInt(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)

--- a/internal/pkg/flagvalue/simple.go
+++ b/internal/pkg/flagvalue/simple.go
@@ -42,8 +42,16 @@ func Simple[T SimpleValue](val T, p *T) Value {
 
 // Set implements the pflag.Value interface.
 func (i *simpleValue[T]) Set(s string) error {
+	return setValue(i.value, s)
+}
+
+// setValue parses s into the value pointed to by p. Strings are assigned
+// verbatim so that values containing whitespace are preserved; all other types
+// fall back to fmt.Sscanf. This is shared by the Simple and SimpleMap values so
+// that they parse scalar values identically.
+func setValue[T any](p *T, s string) error {
 	var err error
-	switch v := any(i.value).(type) {
+	switch v := any(p).(type) {
 	case **string:
 		*v = new(string)
 		**v = s

--- a/internal/pkg/flagvalue/simple_slice.go
+++ b/internal/pkg/flagvalue/simple_slice.go
@@ -29,8 +29,7 @@ func (s *simpleSliceValue[T]) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]T, len(ss))
 	for i, val := range ss {
-		_, err := fmt.Sscanf(val, "%v", &out[i])
-		if err != nil {
+		if err := setValue(&out[i], val); err != nil {
 			return err
 		}
 	}
@@ -87,8 +86,7 @@ func (s *simpleSliceValue[T]) GetSlice() []string {
 
 func (s *simpleSliceValue[T]) fromString(val string) (T, error) {
 	var out T
-	_, err := fmt.Sscanf(val, "%v", &out)
-	if err != nil {
+	if err := setValue(&out, val); err != nil {
 		return out, err
 	}
 

--- a/internal/pkg/flagvalue/simple_slice_test.go
+++ b/internal/pkg/flagvalue/simple_slice_test.go
@@ -98,6 +98,23 @@ func TestSimpleSlice_String(t *testing.T) {
 	r.Equal([]string{"hello", "false", "123"}, s)
 }
 
+func TestSimpleSlice_StringWithSpaces(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	var s []string
+	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	f.AddFlag(&pflag.Flag{
+		Name:  "strings",
+		Value: flagvalue.SimpleSlice[string](nil, &s),
+	})
+
+	// Values containing spaces must be preserved verbatim; only commas
+	// separate elements within a single flag value.
+	r.NoError(f.Parse([]string{"--strings", "Another Project", "--strings", "a b,c d"}))
+	r.Equal([]string{"Another Project", "a b", "c d"}, s)
+}
+
 func TestSimpleSlice_Int(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)


### PR DESCRIPTION
## Description

Map-backed flags such as `-p`/`--pathparam`, `-a`/`--attribute`, and `-f`/`--field` (and `create`'s attributes) truncated their values at the first space. For example, `-p 'name=Another Project'` was parsed as `name=Another`, causing path-param resolution to query `filter[names]=Another` and fail to find the resource.

The root cause was in `flagvalue.SimpleMap`'s `Set` method, which parsed both the key and value of `KEY=VALUE` using `fmt.Sscanf(..., "%v", ...)`. The `%v` verb only scans a string up to the first whitespace, so any value (or key) containing a space was silently cut short. The scalar `flagvalue.Simple` value already avoided this by assigning strings verbatim, but `SimpleMap` never did

## Testing Plan
- Added `TestSimpleMap_StringToStringWithSpaces` which fails before the fix, and passes after.
- `go test ./internal/pkg/flagvalue/ `
- Manually verified `tfctl api /projects/{name} -p'name=Default Project'` now
  resolves the full project name instead of truncating to `Default`.

<!-- Describe a clear reason for this change -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

## The Three Ex's:

### External Links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-38216)

## Example Output

Before:
```bash
$ shweta.murali@shweta tfcloud % tfctl api /projects/{name} -p'name=Default Project'
ERROR: project "Default" not found in organization "practice_testt"
```

After:
```bash
$ shweta.murali@shweta tfcloud % tfctl api /projects/{name} -p'name=Default Project' 
ID:                                                      prj-PkL2AemaaYMVqfMb
Resource:                                                projects
Name:                                                    Default Project
...
```

<!--
One easy way to create a screenshot is:
go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -- tfctl mycommand --myflag
-->

### Extra Things that are Easy to Forget

- [ ] If you added a top level command or global flag, run `make gen/screenshot` to update the README screenshot
- [ ] Think through bash autocomplete prediction for new command targets or flag argument values
