### PR TITLE
Confirm before opening the browser and add guided login output

### DIFF
--- a/internal/commands/auth/login.go
+++ b/internal/commands/auth/login.go
@@ -28,6 +28,11 @@ const (
 	tokenPagePath = "/app/settings/tokens?source=" + version.Name + "-login"
 )
 
+// errLoginCanceled signals that the user declined the interactive confirmation
+// prompt shown before the browser is opened. loginRun treats it as a clean,
+// non-error exit rather than a failure.
+var errLoginCanceled = errors.New("login canceled")
+
 // NewCmdLogin returns the `auth login` command for authenticating.
 func NewCmdLogin(inv *cmd.Invocation) *cmd.Command {
 	opts := &LoginOpts{
@@ -113,6 +118,10 @@ func loginRun(ctx context.Context, inv *cmd.Invocation, opts *LoginOpts) error {
 		token, err = readTokenInteractive(opts, hostname)
 	}
 	if err != nil {
+		// A declined confirmation is a clean, user-initiated exit, not a failure.
+		if errors.Is(err, errLoginCanceled) {
+			return nil
+		}
 		return err
 	}
 
@@ -145,7 +154,9 @@ func readTokenFromStdin(opts *LoginOpts) (string, error) {
 	return token, nil
 }
 
-// readTokenInteractive opens the browser to the token page and prompts the user.
+// readTokenInteractive explains the flow, asks the user to confirm, opens the
+// browser to the token page, and prompts for the generated token. The user must
+// confirm before the browser is opened; declining is a clean exit.
 func readTokenInteractive(opts *LoginOpts, hostname string) (string, error) {
 	if !opts.IO.CanPrompt() {
 		return "", fmt.Errorf("interactive login requires a terminal; use --token to read from stdin")
@@ -154,19 +165,41 @@ func readTokenInteractive(opts *LoginOpts, hostname string) (string, error) {
 	tokenURL := fmt.Sprintf("https://%s%s", hostname, tokenPagePath)
 	cs := opts.IO.ColorScheme()
 
-	fmt.Fprintf(opts.IO.Err(), "Opening browser to create a token at:\n  %s\n\n",
-		cs.String(tokenURL).Bold().String())
+	// Explain what is about to happen and confirm before opening the browser.
+	fmt.Fprintf(opts.IO.Err(),
+		"%s will open the following URL in your browser to create an API token for %s:\n\n  %s\n\n",
+		version.Name,
+		cs.String(hostname).Bold().String(),
+		cs.String(tokenURL).Bold().String(),
+	)
+
+	proceed, err := opts.IO.PromptConfirm("Do you want to proceed")
+	if err != nil {
+		return "", fmt.Errorf("failed to read confirmation: %w", err)
+	}
+	if !proceed {
+		fmt.Fprintln(opts.IO.Err(), "Login canceled.")
+		return "", errLoginCanceled
+	}
+
+	// Open the browser to the token creation page.
+	fmt.Fprint(opts.IO.Err(), "\nOpening your browser to create a token...\n\n")
 
 	openURL := opts.OpenBrowser
 	if openURL == nil {
 		openURL = openBrowser
 	}
 	if err := openURL(tokenURL); err != nil {
-		fmt.Fprintf(opts.IO.Err(), "%s Could not open browser. Please open the URL above manually.\n\n",
+		fmt.Fprintf(opts.IO.Err(),
+			"%s Could not open the browser automatically. Open the URL above manually.\n\n",
 			cs.WarningLabel())
 	}
 
-	fmt.Fprint(opts.IO.Err(), "Paste your token: ")
+	// Prompt for the token and read it without echoing.
+	fmt.Fprintf(opts.IO.Err(),
+		"After creating the token, copy it and paste it below.\n%s will store it for %s.\n\nPaste your token: ",
+		version.Name, cs.String(hostname).Bold().String())
+
 	secret, err := opts.IO.ReadSecret()
 	if err != nil {
 		return "", fmt.Errorf("failed to read token: %w", err)

--- a/internal/commands/auth/login_test.go
+++ b/internal/commands/auth/login_test.go
@@ -230,6 +230,9 @@ func TestLoginInteractive_Success(t *testing.T) {
 	io := iostreams.Test()
 	io.InputTTY = true
 	io.ErrorTTY = true
+	// PromptConfirm (Testing) consumes a single "y" byte; ReadSecret then reads
+	// the remaining bytes as the pasted token.
+	io.Input.WriteString("y")
 	io.Input.WriteString("interactive-token\n")
 
 	opts := &LoginOpts{
@@ -239,7 +242,7 @@ func TestLoginInteractive_Success(t *testing.T) {
 	}
 
 	r.NoError(runLogin(t, opts))
-	r.Contains(io.Error.String(), "Opening browser")
+	r.Contains(io.Error.String(), "Opening your browser")
 	r.Contains(io.Error.String(), "Successfully logged in")
 	r.Contains(io.Error.String(), "interactive-user")
 
@@ -337,6 +340,7 @@ func TestLoginInteractive_DryRun(t *testing.T) {
 	io := iostreams.Test()
 	io.InputTTY = true
 	io.ErrorTTY = true
+	io.Input.WriteString("y")
 	io.Input.WriteString("interactive-token\n")
 
 	opts := &LoginOpts{
@@ -409,4 +413,116 @@ func TestLoginFromStdin_VerifyFails(t *testing.T) {
 	loaded, err := l.LoadProfile(p.Name)
 	r.NoError(err)
 	r.NotEqual("bad-token", loaded.Token)
+}
+
+func TestLoginInteractive_ConfirmOpensBrowserWithSource(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeTFE(t, "interactive-user")
+	l := profile.TestLoader(t)
+	p := l.DefaultProfile()
+	p.Hostname = srv.URL
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	io.InputTTY = true
+	io.ErrorTTY = true
+	// Confirm with a single "y" byte (consumed by PromptConfirm), then the token
+	// (read by ReadSecret).
+	io.Input.WriteString("y")
+	io.Input.WriteString("interactive-token\n")
+
+	var openedURL string
+	opened := false
+	opts := &LoginOpts{
+		IO:      io,
+		Profile: p,
+		Token:   false,
+		OpenBrowser: func(u string) error {
+			opened = true
+			openedURL = u
+			return nil
+		},
+	}
+
+	r.NoError(runLogin(t, opts))
+
+	r.True(opened, "browser is opened after the user confirms")
+	r.Contains(openedURL, "/app/settings/tokens")
+	r.Contains(openedURL, "?source=tfctl-login")
+	r.Contains(io.Error.String(), "Do you want to proceed")
+
+	loaded, err := l.LoadProfile(p.Name)
+	r.NoError(err)
+	r.Equal("interactive-token", loaded.Token)
+}
+
+func TestLoginInteractive_DeclineDoesNotOpenBrowser(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	l := profile.TestLoader(t)
+	p := l.DefaultProfile()
+	r.NoError(p.Write())
+
+	initial, err := l.LoadProfile(p.Name)
+	r.NoError(err)
+	initialToken := initial.Token
+
+	io := iostreams.Test()
+	io.InputTTY = true
+	io.ErrorTTY = true
+	// Decline with a single "n" byte.
+	io.Input.WriteString("n")
+
+	opened := false
+	opts := &LoginOpts{
+		IO:      io,
+		Profile: p,
+		Token:   false,
+		OpenBrowser: func(string) error {
+			opened = true
+			return nil
+		},
+	}
+
+	// Declining is a clean, non-error exit and must not open the browser or
+	// mutate the stored token.
+	r.NoError(runLogin(t, opts))
+	r.False(opened, "browser must not open when the user declines")
+	r.Contains(io.Error.String(), "Login canceled.")
+
+	loaded, err := l.LoadProfile(p.Name)
+	r.NoError(err)
+	r.Equal(initialToken, loaded.Token, "token is unchanged when login is declined")
+}
+
+func TestLoginFromStdin_DoesNotPromptOrOpenBrowser(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	srv := newFakeTFE(t, "testuser")
+	l := profile.TestLoader(t)
+	p := l.DefaultProfile()
+	p.Hostname = srv.URL
+	r.NoError(p.Write())
+
+	io := iostreams.Test()
+	io.Input.WriteString("my-test-token\n")
+
+	opened := false
+	opts := &LoginOpts{
+		IO:      io,
+		Profile: p,
+		Token:   true,
+		OpenBrowser: func(string) error {
+			opened = true
+			return nil
+		},
+	}
+
+	r.NoError(runLogin(t, opts))
+	r.False(opened, "stdin/--token mode must not open a browser")
+	r.NotContains(io.Error.String(), "Do you want to proceed")
 }


### PR DESCRIPTION
## Description

Brings `tfctl auth login`'s interactive terminal experience in line with`terraform login`. Previously the command opened the browser immediately and showed minimal prompting. It now:

1. **Asks for confirmation before opening the browser** by printing the target host and the exact token-creation URL, then prompts with tfctl's standard`PromptConfirm` (`y/n`). Declining is a clean, user-initiated exit (no browser opened, nothing saved).
2. **Prints clearer, step-by-step guidance** around opening the browser and pasting the token, so the flow reads like `terraform login`.

This is purely a terminal-UX change to the **interactive** path. It does **not** change the URL or the `source` query parameter.`tfctl auth login` already opens `/app/settings/tokens?source=tfctl-login`, and that is unchanged. A
companion Atlas change [here](https://github.com/hashicorp/atlas/pull/29384) makes the user token page treat `source=tfctl-login` like `source=terraform-login` (auto-open the create-token modal + paste-back message).
This PR is the CLI half and is independent of that one.

## Testing Plan

**Automated** (`internal/commands/auth/`):
- `go test ./internal/commands/auth/`
- `TestLoginInteractive_ConfirmOpensBrowserWithSource` on `y`, the browser is opened with a URL containing `?source=tfctl-login`, and the token is saved.
- `TestLoginInteractive_DeclineDoesNotOpenBrowser` on `n`, returns cleanly (exit 0), the browser is **not** opened, and the stored token is unchanged.
- `TestLoginFromStdin_DoesNotPromptOrOpenBrowser`: `--token` mode never prompts or opens a browser.
- Updated `TestLoginInteractive_Success` / `TestLoginInteractive_DryRun` to supply the confirmation byte and assert the new messaging.

**Manual** (against `app.staging.terraform.io`):
- Interactive accept: `tfctl auth login` → `y` → browser opens to the exact URL → paste token → `✓ Successfully logged in`.
- Interactive decline: `tfctl auth login` → `n` → `Login canceled.`, no browser, exit 0.
- Non-interactive: `echo "$TOKEN" | tfctl auth login --token` → no prompt/browser, logs in.

<!-- Describe a clear reason for this change -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).

## The Three Ex's:

### External Links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-37686?atlOrigin=eyJpIjoiMThiNjY4Y2MwYzNiNGYzMmIzNzBmYjMzNWM4ZmMzM2IiLCJwIjoiaiJ9)

### Example Output

<!--
One easy way to create a screenshot is:
go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -- tfctl mycommand --myflag
-->


Interactive proceed:

```bash
$ tfctl auth login
tfctl will open the following URL in your browser to create an API token for app.staging.terraform.io:

  https://app.staging.terraform.io/app/settings/tokens?source=tfctl-login

Do you want to proceed (y/n)? y

Opening your browser to create a token...

After creating the token, copy it and paste it below.
tfctl will store it for app.staging.terraform.io.

Paste your token:
✓ Successfully logged in to app.staging.terraform.io as shwetamurali
```

Interactive decline:

```bash
$ tfctl auth login
tfctl will open the following URL in your browser to create an API token for app.staging.terraform.io:

  https://app.staging.terraform.io/app/settings/tokens?source=tfctl-login

Do you want to proceed (y/n)? n

Login canceled.
```

Non-interactive (`--token`, unchanged):

```
$ echo "$MY_TOKEN" | tfctl auth login --token
✓ Successfully logged in to app.staging.terraform.io as shwetamurali
```

### Extra Things that are Easy to Forget

- [ ] If you added a top level command or global flag, run `make gen/screenshot` to update the README screenshot
- [ ] Think through bash autocomplete prediction for new command targets or flag argument values
