### PR TITLE
feat(skills): support amp harness

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260618-111524.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260618-111524.yaml
@@ -1,0 +1,3 @@
+kind: ENHANCEMENTS
+body: The `tfctl harness install amp` command now supports installing the `tfctl` skill into the directories that Amp looks for.
+time: 2026-06-18T11:15:24.079775-04:00

--- a/skills/install.go
+++ b/skills/install.go
@@ -65,6 +65,21 @@ func registerAgents() map[string]AgentSpec {
 	}
 
 	return map[string]AgentSpec{
+		"amp": {
+			Name:        "amp",
+			DisplayName: "Amp CLI",
+			SkillsDir:   ".agents/skills",
+			GlobalSkillsDir: func() string {
+				path, _ := homedir.Expand("~/.config/agents/skills")
+				return path
+			},
+			Detect: func() bool {
+				return detectHomeDirPath(".config/amp")
+			},
+			DetectParentProcess: func() bool {
+				return os.Getenv("AGENT") == "amp"
+			},
+		},
 		"antigravity": {
 			Name:        "antigravity",
 			DisplayName: "Antigravity CLI",


### PR DESCRIPTION
I was surprised to see one of the best agent harnesses, Amp, not listed under the `tfctl harness install` command. We can't let these inferior harnesses get all the attention.

Seriously though, I added support for installing the `tfctl` skill into the directories that Amp looks for.

```
> tfctl harness install amp
✓ Successfully installed tfctl/SKILL.md for Amp CLI to project directory .agents/skills

> head .agents/skills/tfctl/SKILL.md
---
name: tfctl
description: |
  Interact with HCP Terraform / Terraform Cloud using the tfctl CLI. Full API coverage.
  Use for ANY HCP Terraform or Terraform Cloud question or action — listing workspaces,
  starting/diagnosing runs, reading vars, modifying resources, calling API operations.
license: MPL-2.0
---

# tfctl — HCP Terraform CLI
```