### PR TITLE
small change to the skills file

### DIFF
--- a/skills/tfctl/SKILL.md
+++ b/skills/tfctl/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: tfctl
 description: |
-  Interact with HCP Terraform / Terraform Cloud using the tfctl CLI. Full API coverage.
-  Use for ANY HCP Terraform or Terraform Cloud question or action — listing workspaces,
+  Interact with HCP Terraform / Terraform Cloud / Terraform Enterprise using the tfctl CLI. Full API coverage.
+  Use for ANY HCP Terraform or Terraform Cloud or Terraform Enterprise question or action — listing workspaces,
   starting/diagnosing runs, reading vars, modifying resources, calling API operations.
 license: MPL-2.0
 ---


### PR DESCRIPTION
## Description

I tested the skills map and a lot of customers and support people use the Terraform Enterprise name of the product. I added this to the top of the skills so it will use this skill whenever the term Terraform Enterprise is mentioned
