### PR TITLE
add: gemini agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The `tfctl` CLI ships with an agent skill that gives AI coding agents access to 
 - `copilot`
 - `opencode`
 - `pi`
+- `gemini`
 
 To install the skill with `tfctl harness install` command, run:
 

--- a/skills/install.go
+++ b/skills/install.go
@@ -173,6 +173,21 @@ func registerAgents() map[string]AgentSpec {
 				return os.Getenv("PI_CODING_AGENT") == "true"
 			},
 		},
+		"gemini": {
+			Name:        "gemini",
+			DisplayName: "Gemini CLI",
+			SkillsDir:   ".gemini/skills",
+			GlobalSkillsDir: func() string {
+				path, _ := homedir.Expand("~/.gemini/skills")
+				return path
+			},
+			Detect: func() bool {
+				return detectHomeDirPath(".gemini")
+			},
+			DetectParentProcess: func() bool {
+				return os.Getenv("GEMINI_CLI") == "1"
+			},
+		},
 	}
 }
 

--- a/skills/install_test.go
+++ b/skills/install_test.go
@@ -30,6 +30,10 @@ func TestInstallSkill(t *testing.T) {
 			expectedGlobalInstall: "~/.config/opencode/skills/tfctl/SKILL.md",
 		},
 		{
+			agentName:             "gemini",
+			expectedGlobalInstall: "~/.gemini/skills/tfctl/SKILL.md",
+		},
+		{
 			agentName:             "claude",
 			expectedGlobalInstall: "~/CustomClaudeDir/skills/tfctl/SKILL.md",
 			setup: func(t *testing.T) {


### PR DESCRIPTION
Registers Gemini CLI as a supported agent with workspace skills at .gemini/skills and global skills at ~/.gemini/skills, using GEMINI_CLI=1 for parent process detection. Adds corresponding test case and removes duplicate README entry.

Example Output
tfctl harness install gemini --global
✓ Successfully installed tfctl/SKILL.md for Gemini CLI to global directory /Users/dayronremigio/.gemini/skills
