### PR TITLE
Don't retry telemetry on server error

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260630-131853.yaml
+++ b/.changes/unreleased/BUG FIXES-20260630-131853.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: Don't attempt to retry telemetry transmission on server errors, like rate limiting 429 errors.
+time: 2026-06-30T13:18:53.530515-06:00

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -
 
 ### PR Checklist
 
-- [ ] Ensure you have [changie](https://changie.dev/guide/installation/) installed for release notes prep.
+- [ ] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
 - [ ] Ensure any command changes are sensitive to these global flags:
   - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
   - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
@@ -20,7 +20,6 @@ go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -
 - [ ] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
 - [ ] Run `make gen/screenshot` if the root command output changes.
 - [ ] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.
-- [ ] Run `changie new` to prepare a new changelog entry for the next set of release notes.
 
 ## PCI review checklist
 

--- a/README.md
+++ b/README.md
@@ -930,7 +930,7 @@ $ tfctl --version
 
 #### PR Preparation Checklist
 
-1. Ensure you have [changie](https://changie.dev/guide/installation/) installed for release notes prep.
+1. Run `npx changie new` to prepare a new changelog entry for the next set of release notes.
 1. Ensure any command changes are sensitive to these global flags:
   - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
   - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
@@ -939,4 +939,3 @@ $ tfctl --version
 1. Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
 1. Run `make gen/screenshot` if the root command output changes.
 1. Add the `Autocomplete` field to positional arguments and flags to assist shell autocomplete.
-1. Run `changie new` to prepare a new changelog entry for the next set of release notes.

--- a/internal/pkg/telemetry/telemetry.go
+++ b/internal/pkg/telemetry/telemetry.go
@@ -166,6 +166,9 @@ func Init(ctx context.Context, cfg Config) *Telemetry {
 		hostname := resolveEndpoint()
 		opts := []otlptracehttp.Option{
 			otlptracehttp.WithEndpoint(hostname),
+			otlptracehttp.WithRetry(otlptracehttp.RetryConfig{
+				Enabled: false,
+			}),
 		}
 		if strings.HasPrefix(hostname, "localhost") {
 			opts = append(opts, otlptracehttp.WithInsecure())


### PR DESCRIPTION
## Description

By default, the otel http sink will retry if the server responds with a server error. This change disables the behavior.

### PR Checklist

- [x] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
- [x] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Don't render output to stdout.
- [x] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
- [x] Run `make gen/screenshot` if the root command output changes.
- [x] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
