### PR TITLE
run start: add --plan-only flag

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260708-165846.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260708-165846.yaml
@@ -1,0 +1,3 @@
+kind: ENHANCEMENTS
+body: Adds a `--plan-only` flag to `run start` that creates a speculative plan-only run which is never applied, regardless of the workspace's auto-apply setting.
+time: 2026-07-08T16:58:46-04:00

--- a/internal/commands/run/run_start.go
+++ b/internal/commands/run/run_start.go
@@ -37,6 +37,7 @@ type CreateOpts struct {
 	DebuggingMode   bool
 	Message         string
 	AllowEmptyApply bool
+	PlanOnly        bool
 }
 
 // NewCmdRunStart creates the `run start` command.
@@ -54,6 +55,8 @@ func NewCmdRunStart(inv *cmd.Invocation) *cmd.Command {
 		ShortHelp: "Start a new run on a workspace.",
 		LongHelp: heredoc.New(inv.IO, heredoc.WithPreserveNewlines()).Mustf(`
 		The {{ template "mdCodeOrBold" "%s run start" }} command creates a new plan and apply run with the most recent configuration. {{ Bold "If auto-apply is enabled and no errors occur, the plan will be automatically applied." }}
+
+		Use {{ template "mdCodeOrBold" "--plan-only" }} to create a speculative plan-only run that is never applied, regardless of the workspace's auto-apply setting.
 
 		The ID argument can be:
 		- A workspace ID ({{ template "mdCodeOrBold" "ws-abc123" }})
@@ -91,6 +94,12 @@ func NewCmdRunStart(inv *cmd.Invocation) *cmd.Command {
 					Value:         flagvalue.Simple(false, &runOpts.AllowEmptyApply),
 					IsBooleanFlag: true,
 				},
+				{
+					Name:          "plan-only",
+					Description:   "Create a speculative plan-only run that is never applied, regardless of the workspace's auto-apply setting.",
+					Value:         flagvalue.Simple(false, &runOpts.PlanOnly),
+					IsBooleanFlag: true,
+				},
 			},
 		},
 		Examples: []cmd.Example{
@@ -101,6 +110,10 @@ func NewCmdRunStart(inv *cmd.Invocation) *cmd.Command {
 			{
 				Preamble: "Start a new run in a workspace by name",
 				Command:  heredoc.New(inv.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s run start my-workspace --organization my-org`, version.Name),
+			},
+			{
+				Preamble: "Start a plan-only run that will not be applied",
+				Command:  heredoc.New(inv.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s run start ws-abc123 --plan-only`, version.Name),
 			},
 		},
 		RunF: func(_ *cmd.Command, args []string) error {
@@ -201,6 +214,7 @@ func buildRunsEnvelope(wsID string, ro CreateOpts) *models.RunsEnvelope {
 	attributes := models.NewRuns_attributes()
 	attributes.SetMessage(&ro.Message)
 	attributes.SetAllowEmptyApply(&ro.AllowEmptyApply)
+	attributes.SetPlanOnly(&ro.PlanOnly)
 
 	if ro.DebuggingMode {
 		// This attribute is missing from the API spec! If you are reading this, it's been added by now

--- a/internal/commands/run/run_start_test.go
+++ b/internal/commands/run/run_start_test.go
@@ -256,6 +256,58 @@ func TestRunStart(t *testing.T) {
 		assert.Contains(t, io.Error.String(), "run-fromname")
 	})
 
+	t.Run("plan-only run sets plan-only attribute", func(t *testing.T) {
+		t.Parallel()
+		io := iostreams.Test()
+
+		c := testAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch route(r) {
+			case "GET /api/v2/workspaces/ws-abc123":
+				jsonapi(w, map[string]any{
+					"data": map[string]any{
+						"id": "ws-resolved", "type": "workspaces",
+						"attributes": map[string]any{"name": "foobar"},
+						"relationships": map[string]any{
+							"organization": map[string]any{
+								"data": map[string]any{
+									"id": "org-resolved", "type": "organizations",
+								},
+							},
+						},
+					},
+				})
+			case "POST /api/v2/runs":
+				var body map[string]any
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				data := body["data"].(map[string]any)
+				attrs := data["attributes"].(map[string]any)
+				assert.Equal(t, true, attrs["plan-only"])
+
+				jsonapi(w, map[string]any{
+					"data": map[string]any{
+						"id": "run-planonly", "type": "runs",
+						"attributes": map[string]any{"status": "pending"},
+					},
+				})
+			default:
+				http.Error(w, "unexpected: "+route(r), http.StatusInternalServerError)
+			}
+		}))
+
+		err := runStart(context.Background(), StartOpts{
+			IO:        io,
+			APIClient: c,
+			Profile:   profile.TestProfile(t),
+			Workspace: "ws-abc123",
+			DryRun:    false,
+		}, CreateOpts{
+			PlanOnly: true,
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, io.Error.String(), "run-planonly")
+	})
+
 	t.Run("API error on run creation", func(t *testing.T) {
 		t.Parallel()
 		io := iostreams.Test()


### PR DESCRIPTION
## Description

`run start` currently always creates a plan-and-apply run, so on a workspace with
auto-apply enabled it applies automatically, and there is no way to request a
speculative plan from the CLI. HCP Terraform / TFE supports this natively via the
run `plan-only` attribute; this change exposes it.

This adds a `--plan-only` flag to `run start` that sets the run's `plan-only`
attribute, creating a speculative plan-only run that is never applied, regardless
of the workspace's auto-apply setting. The implementation mirrors the existing
`--allow-empty-apply` flag: a boolean on `CreateOpts`, applied via
`attributes.SetPlanOnly(...)` in `buildRunsEnvelope`.

### Example Output

```
$ tfctl run start my-workspace --plan-only
✓ run-XXXXXXXX created. You can monitor the status of the run using:

$ tfctl run status run-XXXXXXXX
```

Verified end to end against a workspace with auto-apply enabled: the created run
reported `plan-only: true` and reached `planned_and_finished` without applying,
confirming the flag overrides auto-apply. `--dry-run` is also honored (no run is
created).

### PR Checklist

- [x] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
  - Added `.changes/unreleased/ENHANCEMENTS-*.yaml` (kind: ENHANCEMENTS).
- [x] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Don't render output to stdout.
  - `--dry-run` is respected (skips run creation). `run start` writes only to stderr and emits no stdout data payload, so `--json`/`--markdown`/`--quiet` behavior is unchanged.
- [x] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
  - No new nonfatal conditions are introduced; existing logging is sufficient.
- [x] Run `make gen/screenshot` if the root command output changes.
  - Not required: root command output is unchanged (this adds a subcommand flag).
- [x] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.
  - N/A: `--plan-only` is a boolean flag with no value to complete.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  - Reverting the PR fully removes the change; no additional revert steps or data migration.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
  - N/A: no security-control changes (no access-control, logging-pipeline, or authentication changes).
