### PR TITLE
Fix TF_TOKEN_<host> env var lookup for auth

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260709-163223.yaml
+++ b/.changes/unreleased/BUG FIXES-20260709-163223.yaml
@@ -1,3 +1,3 @@
 kind: BUG FIXES
-body: Honor the standard Terraform `TF_TOKEN_<hostname>` environment variables (such as `TF_TOKEN_app_terraform_io`) during authentication. The hostname is no longer uppercased when building the variable name, so these tokens are now detected as documented.
+body: Detect Terraform's `TF_TOKEN_<hostname>` environment variables (such as `TF_TOKEN_app_terraform_io`) during authentication, matching Terraform CLI's resolution. This includes punycode hostnames and the interchangeable dash encodings (literal `-` or double underscore). Previously these tokens were not detected.
 time: 2026-07-09T16:32:23.267381-04:00

--- a/.changes/unreleased/BUG FIXES-20260709-163223.yaml
+++ b/.changes/unreleased/BUG FIXES-20260709-163223.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: Honor the standard Terraform `TF_TOKEN_<hostname>` environment variables (such as `TF_TOKEN_app_terraform_io`) during authentication. The hostname is no longer uppercased when building the variable name, so these tokens are now detected as documented.
+time: 2026-07-09T16:32:23.267381-04:00

--- a/internal/pkg/profile/loader.go
+++ b/internal/pkg/profile/loader.go
@@ -354,11 +354,13 @@ func terraformTokenEnvVar(hostname string) string {
 	}
 
 	// Match Terraform CLI's TF_TOKEN_<host> naming scheme so that variables like
-	// TF_TOKEN_app_terraform_io are honored. The (already normalized, lowercase,
-	// punycode) hostname is encoded by replacing hyphens with double underscores
+	// TF_TOKEN_app_terraform_io are honored. Terraform lowercases the hostname;
+	// NormalizeHostname doesn't when a port is present, so lowercase explicitly.
+	// The hostname is then encoded by replacing hyphens with double underscores
 	// and periods with single underscores. Any other character that isn't a
 	// letter or digit is also replaced with a single underscore.
 	// See https://developer.hashicorp.com/terraform/cli/config/config-file#environment-variable-credentials
+	hostname = strings.ToLower(hostname)
 	hostname = strings.ReplaceAll(hostname, "-", "__")
 
 	var b strings.Builder

--- a/internal/pkg/profile/loader.go
+++ b/internal/pkg/profile/loader.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -256,11 +255,11 @@ func (l *Loader) LoadProfile(ctx context.Context, name string) (*Profile, error)
 		}
 	}
 
-	// 3. Check for a token in the terraform environment variable that matches the hostname of the
-	// profile (support for TF_TOKEN_{normalizedHostname}
+	// 3. Check for a token in a terraform environment variable that matches the hostname of the
+	// profile (support for TF_TOKEN_{host}).
 	if c.GetToken() == "" {
-		if envToken := os.Getenv(terraformTokenEnvVar(c.GetHostname())); envToken != "" {
-			logger.Debug("Setting token from terraform environment", "var", terraformTokenEnvVar(c.GetHostname()))
+		if envToken := tokenFromTerraformEnv(c.GetHostname()); envToken != "" {
+			logger.Debug("Setting token from terraform environment", "hostname", c.GetHostname())
 			c.tokenFromEnv = envToken
 		}
 	}
@@ -347,32 +346,57 @@ func profileTokenEnvVar(profileName string) string {
 	return fmt.Sprintf(envVarTokenProfileFormat, profileName)
 }
 
-func terraformTokenEnvVar(hostname string) string {
-	hostname, err := NormalizeHostname(hostname)
+// tokenFromTerraformEnv returns the token from a Terraform-style TF_TOKEN_<host>
+// environment variable that matches the given hostname, mirroring Terraform CLI's
+// resolution. Terraform scans every environment variable with the TF_TOKEN_ prefix
+// and decodes the remainder of the name back into a hostname: double underscores
+// become hyphens and any remaining single underscore becomes a period. This means a
+// single hostname may be expressed by several variable names (for example the
+// punycode host xn--caf-dma.fr can be written as TF_TOKEN_xn--caf-dma_fr,
+// TF_TOKEN_xn--caf-dma.fr, or TF_TOKEN_xn____caf__dma_fr). If multiple variables
+// resolve to the same hostname, the one defined last wins.
+// See https://developer.hashicorp.com/terraform/cli/config/config-file#environment-variable-credentials
+func tokenFromTerraformEnv(hostname string) string {
+	target, err := NormalizeHostname(hostname)
 	if err != nil {
 		return ""
 	}
+	// Terraform's encoding can only produce periods (via single underscores), so a
+	// hostname's port separator (":") is indistinguishable from a period once
+	// encoded. Normalize both sides to periods so ported hosts like
+	// app.terraform.io:8443 still match TF_TOKEN_app_terraform_io_8443.
+	target = normalizeTerraformTokenHost(target)
 
-	// Match Terraform CLI's TF_TOKEN_<host> naming scheme so that variables like
-	// TF_TOKEN_app_terraform_io are honored. Terraform lowercases the hostname;
-	// NormalizeHostname doesn't when a port is present, so lowercase explicitly.
-	// The hostname is then encoded by replacing hyphens with double underscores
-	// and periods with single underscores. Any other character that isn't a
-	// letter or digit is also replaced with a single underscore.
-	// See https://developer.hashicorp.com/terraform/cli/config/config-file#environment-variable-credentials
-	hostname = strings.ToLower(hostname)
-	hostname = strings.ReplaceAll(hostname, "-", "__")
-
-	var b strings.Builder
-	b.WriteString("TF_TOKEN_")
-	for _, r := range hostname {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
-			b.WriteRune(r)
+	const prefix = "TF_TOKEN_"
+	var token string
+	for _, env := range os.Environ() {
+		name, value, ok := strings.Cut(env, "=")
+		if !ok || !strings.HasPrefix(name, prefix) {
 			continue
 		}
-		b.WriteRune('_')
+
+		// Decode Terraform's encoding of the hostname portion: double underscores
+		// are hyphens, and any remaining single underscore is a period.
+		rawHost := name[len(prefix):]
+		rawHost = strings.ReplaceAll(rawHost, "__", "-")
+		rawHost = strings.ReplaceAll(rawHost, "_", ".")
+
+		candidate, err := NormalizeHostname(rawHost)
+		if err != nil {
+			continue
+		}
+		if normalizeTerraformTokenHost(candidate) == target {
+			// Keep going so the last-defined matching variable wins.
+			token = value
+		}
 	}
-	return b.String()
+	return token
+}
+
+// normalizeTerraformTokenHost lowercases a hostname and treats the port separator
+// as a period so that encoded and decoded forms compare equal.
+func normalizeTerraformTokenHost(hostname string) string {
+	return strings.ReplaceAll(strings.ToLower(hostname), ":", ".")
 }
 
 type credentialsFile struct {

--- a/internal/pkg/profile/loader.go
+++ b/internal/pkg/profile/loader.go
@@ -353,10 +353,18 @@ func terraformTokenEnvVar(hostname string) string {
 		return ""
 	}
 
+	// Match Terraform CLI's TF_TOKEN_<host> naming scheme so that variables like
+	// TF_TOKEN_app_terraform_io are honored. The (already normalized, lowercase,
+	// punycode) hostname is encoded by replacing hyphens with double underscores
+	// and periods with single underscores. Any other character that isn't a
+	// letter or digit is also replaced with a single underscore.
+	// See https://developer.hashicorp.com/terraform/cli/config/config-file#environment-variable-credentials
+	hostname = strings.ReplaceAll(hostname, "-", "__")
+
 	var b strings.Builder
 	b.WriteString("TF_TOKEN_")
-	for _, r := range strings.ToUpper(hostname) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+	for _, r := range hostname {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
 			b.WriteRune(r)
 			continue
 		}

--- a/internal/pkg/profile/loader_test.go
+++ b/internal/pkg/profile/loader_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -227,46 +228,100 @@ func TestLoader_GetDeviceID(t *testing.T) {
 	require.Equal(t, id, id2)
 }
 
-func TestTerraformTokenEnvVar(t *testing.T) {
-	t.Parallel()
-
+//nolint:paralleltest // manipulates the environment, can't run in parallel
+func TestTokenFromTerraformEnv(t *testing.T) {
 	cases := []struct {
 		name     string
 		hostname string
+		env      map[string]string
 		expected string
 	}{
 		{
-			name:     "hcp terraform hostname uses lowercase, matching terraform",
+			name:     "hcp terraform token via lowercase variable",
 			hostname: "app.terraform.io",
-			expected: "TF_TOKEN_app_terraform_io",
+			env:      map[string]string{"TF_TOKEN_app_terraform_io": "tok"},
+			expected: "tok",
 		},
 		{
-			name:     "mixed-case hostname is normalized to lowercase",
-			hostname: "App.Terraform.IO",
-			expected: "TF_TOKEN_app_terraform_io",
+			name:     "uppercase variable name still matches",
+			hostname: "app.terraform.io",
+			env:      map[string]string{"TF_TOKEN_APP_TERRAFORM_IO": "tok"},
+			expected: "tok",
 		},
 		{
-			name:     "mixed-case hostname with port is normalized to lowercase",
-			hostname: "App.Terraform.IO:8443",
-			expected: "TF_TOKEN_app_terraform_io_8443",
+			name:     "hostname with port matches",
+			hostname: "app.terraform.io:8443",
+			env:      map[string]string{"TF_TOKEN_app_terraform_io_8443": "tok"},
+			expected: "tok",
 		},
 		{
-			name:     "hyphens are encoded as double underscores",
+			name:     "hyphenated hostname via literal dashes",
 			hostname: "my-tfe.example.com",
-			expected: "TF_TOKEN_my__tfe_example_com",
+			env:      map[string]string{"TF_TOKEN_my-tfe_example_com": "tok"},
+			expected: "tok",
 		},
 		{
-			name:     "invalid hostname returns an empty string",
+			name:     "hyphenated hostname via double underscores",
+			hostname: "my-tfe.example.com",
+			env:      map[string]string{"TF_TOKEN_my__tfe_example_com": "tok"},
+			expected: "tok",
+		},
+		{
+			name:     "punycode hostname via literal dashes and period",
+			hostname: "café.fr",
+			env:      map[string]string{"TF_TOKEN_xn--caf-dma.fr": "tok"},
+			expected: "tok",
+		},
+		{
+			name:     "punycode hostname via literal dashes",
+			hostname: "café.fr",
+			env:      map[string]string{"TF_TOKEN_xn--caf-dma_fr": "tok"},
+			expected: "tok",
+		},
+		{
+			name:     "punycode hostname via double underscores",
+			hostname: "café.fr",
+			env:      map[string]string{"TF_TOKEN_xn____caf__dma_fr": "tok"},
+			expected: "tok",
+		},
+		{
+			name:     "no matching variable returns empty",
+			hostname: "app.terraform.io",
+			env:      map[string]string{"TF_TOKEN_other_example_com": "tok"},
+			expected: "",
+		},
+		{
+			name:     "invalid hostname returns empty",
 			hostname: "invalid/hostname",
+			env:      map[string]string{"TF_TOKEN_app_terraform_io": "tok"},
 			expected: "",
 		},
 	}
 
 	for _, c := range cases {
+		//nolint:paralleltest // uses t.Setenv
 		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, c.expected, terraformTokenEnvVar(c.hostname))
+			clearTerraformTokenEnv(t)
+			for k, v := range c.env {
+				t.Setenv(k, v)
+			}
+			require.Equal(t, c.expected, tokenFromTerraformEnv(c.hostname))
 		})
+	}
+}
+
+// clearTerraformTokenEnv removes any TF_TOKEN_* variables already present in the
+// test runner's environment so the test controls exactly which ones are set. The
+// original values are restored when the test finishes.
+func clearTerraformTokenEnv(t *testing.T) {
+	t.Helper()
+	for _, env := range os.Environ() {
+		name, _, ok := strings.Cut(env, "=")
+		if !ok || !strings.HasPrefix(name, "TF_TOKEN_") {
+			continue
+		}
+		t.Setenv(name, "") // registers restoration of the original value
+		require.NoError(t, os.Unsetenv(name))
 	}
 }
 

--- a/internal/pkg/profile/loader_test.go
+++ b/internal/pkg/profile/loader_test.go
@@ -246,6 +246,11 @@ func TestTerraformTokenEnvVar(t *testing.T) {
 			expected: "TF_TOKEN_app_terraform_io",
 		},
 		{
+			name:     "mixed-case hostname with port is normalized to lowercase",
+			hostname: "App.Terraform.IO:8443",
+			expected: "TF_TOKEN_app_terraform_io_8443",
+		},
+		{
 			name:     "hyphens are encoded as double underscores",
 			hostname: "my-tfe.example.com",
 			expected: "TF_TOKEN_my__tfe_example_com",

--- a/internal/pkg/profile/loader_test.go
+++ b/internal/pkg/profile/loader_test.go
@@ -227,6 +227,44 @@ func TestLoader_GetDeviceID(t *testing.T) {
 	require.Equal(t, id, id2)
 }
 
+func TestTerraformTokenEnvVar(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		hostname string
+		expected string
+	}{
+		{
+			name:     "hcp terraform hostname uses lowercase, matching terraform",
+			hostname: "app.terraform.io",
+			expected: "TF_TOKEN_app_terraform_io",
+		},
+		{
+			name:     "mixed-case hostname is normalized to lowercase",
+			hostname: "App.Terraform.IO",
+			expected: "TF_TOKEN_app_terraform_io",
+		},
+		{
+			name:     "hyphens are encoded as double underscores",
+			hostname: "my-tfe.example.com",
+			expected: "TF_TOKEN_my__tfe_example_com",
+		},
+		{
+			name:     "invalid hostname returns an empty string",
+			hostname: "invalid/hostname",
+			expected: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, c.expected, terraformTokenEnvVar(c.hostname))
+		})
+	}
+}
+
 //nolint:paralleltest
 func TestLoader_LoadProfileEnv(t *testing.T) {
 	// These tests aren't parallel because they manipulate the environment

--- a/internal/pkg/profile/profile_test.go
+++ b/internal/pkg/profile/profile_test.go
@@ -158,6 +158,18 @@ func TestNormalizeHostname(t *testing.T) {
 			Expected: "xn--tst-qla.com",
 		},
 		{
+			// Documented Terraform example: https://developer.hashicorp.com/terraform/cli/config/config-file#environment-variable-credentials
+			Name:     "unicode hostname converts to punycode (café.fr)",
+			Input:    "café.fr",
+			Expected: "xn--caf-dma.fr",
+		},
+		{
+			// Documented Terraform example for a non-ASCII host.
+			Name:     "unicode hostname converts to punycode (例えば.com)",
+			Input:    "例えば.com",
+			Expected: "xn--r8j3dr99h.com",
+		},
+		{
 			Name:     "ipv4 hostname with port",
 			Input:    "127.0.0.1:9000",
 			Expected: "127.0.0.1:9000",


### PR DESCRIPTION
## Description

`tfctl` documents that it honors Terraform's `TF_TOKEN_app_terraform_io` env var for auth, but it never actually matched. When building the lookup name, `terraformTokenEnvVar` uppercased the hostname, so it searched for `TF_TOKEN_APP_TERRAFORM_IO` instead of the standard lowercase `TF_TOKEN_app_terraform_io`. Since env var names are case-sensitive, the standard Terraform-style variable was silently ignored.

This aligns the name-building with Terraform CLI's `TF_TOKEN_<host>` scheme:
- hostname stays lowercase (as normalized)
- hyphens encode as double underscores (`__`)
- periods encode as single underscores (`_`)

### Testing
- Added`TestTerraformTokenEnvVar`

### PR Checklist

- [X] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
- [ ] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Don't render output to stdout.
- [ ] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
- [ ] Run `make gen/screenshot` if the root command output changes.
- [ ] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
