### PR TITLE
Reword 404 "not found" error help

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260710-135409.yaml
+++ b/.changes/unreleased/BUG FIXES-20260710-135409.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: Clarify the not-found (404) API error message to point at verifying the request path and resource IDs instead of suggesting an authentication problem.
+time: 2026-07-10T13:54:09.690093-04:00

--- a/internal/pkg/cmd/command_internal.go
+++ b/internal/pkg/cmd/command_internal.go
@@ -165,10 +165,10 @@ func (c *Command) Run(args []string, inv *Invocation) int {
 
 func notFoundErrorHelp(io iostreams.IOStreams, hostname string) string {
 	return heredoc.New(io, heredoc.WithPreserveNewlines(), heredoc.WithWidth(0)).Mustf(`
-		Resource not found on {{ Bold "%s" }} or you are unauthorized to this action. Check your account permissions.
+		Resource or path not found on {{ Bold "%s" }}. Verify the API path and any resource IDs are correct.
 
-		  {{ Bold "$ %s auth status" }}
-	`, hostname, version.Name)
+		If the path is correct, your token may not have permission to access this resource.
+	`, hostname)
 }
 
 // authErrorHelp returns a help message for recovering from authentication errors.

--- a/internal/pkg/cmd/command_test.go
+++ b/internal/pkg/cmd/command_test.go
@@ -137,7 +137,7 @@ func TestCommand_GlobalExitCode(t *testing.T) {
 	}{
 		{err: ErrDisplayHelp, expected: cli.RunResultHelp},
 		{err: ErrDisplayUsage, expected: 1},
-		{err: tfe.ErrNotFound, expected: 2, errContains: "Resource not found on app.test.terraform.io or you are unauthorized to this action"},
+		{err: tfe.ErrNotFound, expected: 2, errContains: "Resource or path not found on app.test.terraform.io. Verify the API path and any resource IDs are correct."},
 		{err: tfe.ErrUnauthorized, expected: 3, errContains: "tfctl auth login"},
 		{err: opErr, expected: 4, errContains: "network error"},
 		{err: tfe.ErrInternalServer, expected: 5, errContains: "Internal Server Error"},


### PR DESCRIPTION
## Description

Reword the 404 "not found" error help so it no longer conflates "resource/path not found" with an authentication/authorization problem.

A customer reported their LLM-driven agent thrashing when driving `tfctl api`. Reviewing the trace, the agent repeatedly hit 404s on paths that don't exist (e.g. no-code module sub-endpoints) and interpreted the error as an auth failure because the message led with "or you are unauthorized" and nudged toward `tfctl auth status`. That sent it down a token/credentials/`curl` debugging path instead of correcting the endpoint, costing many extra iterations.

The 404 case (`tfe.ErrNotFound`) is already cleanly separated from real 401s (`tfe.ErrUnauthorized`, which keeps its own `auth login` help), so this is purely a wording fix. The new message leads with the actual cause which is a wrong path/ID while still honestly noting that HCP/TFE can return 404 for resources the token can't see, without steering toward auth tooling.


### Example Output

**Before:**
> Resource not found on `<host>` or you are unauthorized to this action. Check your account permissions.
>
>   `$ tfctl auth status`

**After:**
> Resource or path not found on `<host>`. Verify the API path and any resource IDs are correct.
>
> If the path is correct, your token may not have permission to access this resource.

### PR Checklist

- [X] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
- [ ] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Don't render output to stdout.
- [ ] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
- [ ] Run `make gen/screenshot` if the root command output changes.
- [ ] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
