### PR TITLE
api: fix --all returning no output on single-page results

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260713-133903.yaml
+++ b/.changes/unreleased/BUG FIXES-20260713-133903.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: Fix `api --all` returning no output when the result fits in a single page. The response body was consumed while checking for additional pages and not restored, so single-page responses rendered empty.
+time: 2026-07-13T13:39:03-04:00

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -694,7 +694,10 @@ func paginateResponse(ctx context.Context, apiClient *client.Client, initial *ht
 
 	combined, nextURL, err := parsePaginationPayload(initialBody)
 	if err != nil || nextURL == nil {
-
+		// io.ReadAll above consumed initial.Body. There is nothing to paginate
+		// (single page, or the payload isn't a paginated collection), so restore
+		// the body for the caller to read.
+		initial.Body = io.NopCloser(bytes.NewReader(initialBody))
 		return initial, err
 	}
 

--- a/internal/commands/api/api_paginate_singlepage_test.go
+++ b/internal/commands/api/api_paginate_singlepage_test.go
@@ -1,0 +1,47 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
+)
+
+// TestRunAPI_PaginateSinglePage covers the case where --all is set but the
+// result fits in a single page (no "next" link). The response body must still
+// be rendered; a single-page result must not come back empty just because
+// pagination was requested.
+func TestRunAPI_PaginateSinglePage(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"GET /api/v2/workspaces": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": []any{
+					map[string]any{"id": "ws-1", "type": "workspaces", "attributes": map[string]any{"name": "alpha"}},
+				},
+				"links": map[string]any{"next": nil},
+				"meta":  map[string]any{"pagination": map[string]any{"total-count": 1}},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := RunAPI(context.Background(), newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces")
+		opts.All = true
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, recorder.All(), 1)
+	require.Contains(t, io.Output.String(), "alpha",
+		"single-page --all result must still be rendered, got: %q", io.Output.String())
+	require.Empty(t, io.Error.String())
+}


### PR DESCRIPTION
## Description

`tfctl api --all` returns no output when the result fits in a single page. In
`paginateResponse`, the initial response body is read in full to look for a
`next` pagination link. On the single-page path (no `next` link, or the payload
is not a paginated collection) the function returned the response without
restoring that drained body, so rendering saw an empty body. In practice this
surfaced as a `not a JSON:API envelope` error rather than the expected result.

This restores the buffered body before returning on that path, mirroring what
the multi-page path already does when it re-wraps the merged body.

### Example Output

Before (against a resource whose result fits on one page):

```
$ tfctl api /organizations/my-org/workspaces --all
Error: not a JSON:API envelope
```

After:

```
$ tfctl api /organizations/my-org/workspaces --all
# renders the workspaces as usual
```

### PR Checklist

- [x] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
  - Added `.changes/unreleased/BUG FIXES-*.yaml` (kind: BUG FIXES).
- [x] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Don't render output to stdout.
  - No new flags or output modes. The fix restores the response body so all existing output paths (`--json`/`--markdown`/`--quiet`) render as they would for a non-`--all` request. `--dry-run` is not applicable to `api` GET pagination.
- [x] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
  - No new nonfatal conditions are introduced.
- [x] Run `make gen/screenshot` if the root command output changes.
  - Not required: root command output is unchanged.
- [x] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.
  - N/A: no new arguments or flags.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  - Reverting the PR fully removes the change; no additional revert steps or data migration.

- [x] If applicable, I've documented the impact of any changes to security controls.
  - N/A: no security-control changes.
