### PR TITLE
format: stop leaking relationship IDs into JSON:API attributes in --json/--jq

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260713-133938.yaml
+++ b/.changes/unreleased/BUG FIXES-20260713-133938.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: Fix `api` `--json` and `--jq` output incorrectly including one-to-one relationship IDs under `attributes`. Those IDs are surfaced for table and pretty output only, and are no longer written back into the raw JSON payload.
+time: 2026-07-13T13:39:38-04:00

--- a/internal/pkg/format/jsonapi.go
+++ b/internal/pkg/format/jsonapi.go
@@ -220,6 +220,14 @@ func resourceAsMap(item any) (map[string]any, bool) {
 		return nil, false
 	}
 
+	// Copy attributes into the row. We must not mutate attrMap directly: it is
+	// shared with the raw payload that backs --json / --jq output, and pulling
+	// relationship IDs into it would pollute that output with keys the server
+	// never returned under "attributes".
+	for key, value := range attrMap {
+		row[key] = value
+	}
+
 	// Look for one-to-one relationships and pull the ID up to the top level of the row for display.
 	rels, ok := obj["relationships"]
 	if ok {
@@ -233,14 +241,11 @@ func resourceAsMap(item any) (map[string]any, bool) {
 				continue
 			}
 			if oneToOne, isOneToOne := data.(map[string]any); isOneToOne {
-				attrMap[rel] = oneToOne["id"]
+				row[rel] = oneToOne["id"]
 			}
 		}
 	}
 
-	for key, value := range attrMap {
-		row[key] = value
-	}
 	flattenRow(row)
 	return row, true
 }

--- a/internal/pkg/format/jsonapi_mutation_test.go
+++ b/internal/pkg/format/jsonapi_mutation_test.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package format_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/tfctl-cli/internal/pkg/format"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
+)
+
+// A JSON:API envelope with a one-to-one relationship. The displayer pulls the
+// relationship ID up into the flattened rows for table/pretty display, but it
+// must not mutate the raw envelope that feeds --json / --jq output.
+const relEnvelope = `{
+  "data": [
+    {
+      "id": "ws-abc123",
+      "type": "workspaces",
+      "attributes": {
+        "name": "my-workspace",
+        "auto-apply": false
+      },
+      "relationships": {
+        "organization": {
+          "data": {"id": "org-xyz789", "type": "organizations"}
+        }
+      }
+    }
+  ]
+}`
+
+// TestJSONAPI_JSONOutput_NotPollutedByRelationshipID asserts that JSON output
+// reflects the server payload exactly: the relationship ID must NOT be injected
+// into data[].attributes.
+func TestJSONAPI_JSONOutput_NotPollutedByRelationshipID(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	disp, err := format.NewJSONAPIDisplayer([]byte(relEnvelope), hclog.Default())
+	r.NoError(err)
+
+	io := iostreams.Test()
+	out := format.New(io)
+	out.SetFormat(format.JSON)
+	r.NoError(out.Display(disp))
+
+	var parsed struct {
+		Data []struct {
+			Attributes map[string]any `json:"attributes"`
+		} `json:"data"`
+	}
+	r.NoError(json.Unmarshal(io.Output.Bytes(), &parsed))
+	r.Len(parsed.Data, 1)
+
+	attrs := parsed.Data[0].Attributes
+	r.Contains(attrs, "name", "real attributes should survive")
+	r.NotContains(attrs, "organization",
+		"relationship ID must not be injected into attributes in JSON output; got %v", attrs)
+}
+
+// TestJSONAPI_PayloadStableAcrossFormats asserts the raw payload is not mutated
+// as a side effect of rendering a table (which pulls relationship IDs up).
+func TestJSONAPI_PayloadStableAcrossFormats(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	disp, err := format.NewJSONAPIDisplayer([]byte(relEnvelope), hclog.Default())
+	r.NoError(err)
+
+	// Render as a table first (this is what triggers the relationship pull-up).
+	tableIO := iostreams.Test()
+	tableOut := format.New(tableIO)
+	tableOut.SetFormat(format.Table)
+	r.NoError(tableOut.Display(disp))
+
+	// Now render JSON from the same displayer and confirm attributes are clean.
+	jsonIO := iostreams.Test()
+	jsonOut := format.New(jsonIO)
+	jsonOut.SetFormat(format.JSON)
+	r.NoError(jsonOut.Display(disp))
+
+	var parsed struct {
+		Data []struct {
+			Attributes map[string]any `json:"attributes"`
+		} `json:"data"`
+	}
+	r.NoError(json.Unmarshal(jsonIO.Output.Bytes(), &parsed))
+	r.Len(parsed.Data, 1)
+	r.NotContains(parsed.Data[0].Attributes, "organization",
+		"raw payload was mutated by table rendering; attributes = %v", parsed.Data[0].Attributes)
+}


### PR DESCRIPTION
## Description

For `tfctl api`, one-to-one relationship IDs are pulled up into the flattened
row so they show in table and pretty output (e.g. an `organization` column).
`resourceAsMap` did this by writing the ID into the resource's `attributes`
map, but that map is aliased from the raw JSON:API payload that backs `--json`
and `--jq` output. As a result the pulled-up IDs leaked into `attributes` in
JSON output, keys the server never returned under `attributes`, corrupting
machine-readable output.

This writes the pulled-up relationship IDs into the per-display row instead of
mutating the shared `attributes` map, so table/pretty output is unchanged while
`--json`/`--jq` reflect the server payload exactly.

### Example Output

Given a workspace with an `organization` relationship, before:

```
$ tfctl api /organizations/my-org/workspaces/my-ws --json | jq '.data.attributes | keys'
[
  "auto-apply",
  "name",
  "organization"
]
```

After:

```
$ tfctl api /organizations/my-org/workspaces/my-ws --json | jq '.data.attributes | keys'
[
  "auto-apply",
  "name"
]
```

### PR Checklist

- [x] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
  - Added `.changes/unreleased/BUG FIXES-*.yaml` (kind: BUG FIXES).
- [x] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Don't render output to stdout.
  - This directly fixes `--json`/`--jq` output. Table/pretty (`--markdown` included) output is unchanged; a regression test confirms the existing pull-up display behavior still holds.
- [x] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
  - No new nonfatal conditions are introduced.
- [x] Run `make gen/screenshot` if the root command output changes.
  - Not required: root command output is unchanged.
- [x] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.
  - N/A: no new arguments or flags.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  - Reverting the PR fully removes the change; no additional revert steps or data migration.

- [x] If applicable, I've documented the impact of any changes to security controls.
  - N/A: no security-control changes.
