### PR TITLE
make cleanup-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ASSETS ?= assets
 VERSION_FILE ?= version/VERSION
 SKILL_HASHES = skills/tfctl/known_release_hashes
 SKILL_EMBEDDED = skills/tfctl/SKILL.md
+CHANGELOG_FILE = CHANGELOG.md
 
 ifeq ($(GOARCH), arm64)
 	GOARCH = arm64
@@ -82,6 +83,17 @@ prepare-release: gen/openapi
 	@echo "$$(shasum -a 256 $(SKILL_EMBEDDED) | cut -d' ' -f1) v$(VERSION)" >> $(SKILL_HASHES)
 	@echo "Appended sha256 for $(SKILL_EMBEDDED) to $(SKILL_HASHES)"
 
+.PHONY: cleanup-release
+cleanup-release:
+	@if [ -z "$(DEV_VERSION)" ]; then echo "DEV_VERSION is not set"; exit 1; fi
+	@if ! $$(git tag -l v$$(cat version/VERSION) >/dev/null 2>&1); then echo "Lastest version $$(cat version/VERSION) has not been released"; exit 1; fi
+
+	@echo $(DEV_VERSION) > $(VERSION_FILE)
+	@echo "## Unreleased" > $(CHANGELOG_FILE)
+	@echo "" >> $(CHANGELOG_FILE)
+	@echo "This file will be populated by automation before release. See this [CHANGELOG.md](https://github.com/hashicorp/tfctl-cli/blob/v$(VERSION)/CHANGELOG.md) for information about the latest release." >> $(CHANGELOG_FILE)
+	@echo "Release cleanup finished, version is now $(DEV_VERSION)"
+
 # Install development tools
 .PHONY: tools
 tools:
@@ -135,4 +147,6 @@ help:
 	@echo " gen/openapi      Update embedded OpenAPI spec"
 	@echo " prepare-release  Prepare next semantic version release,"
 	@echo "                  requires VERSION argument"
+	@echo " cleanup-release  Clean up after a release"
+	@echo "                  requires DEV_VERSION argument"
 	@echo ""


### PR DESCRIPTION
## Description

`make cleanup-release` Prepares the repository for the next release

### Example Output

<!--
One easy way to create a screenshot is:
go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -- tfctl mycommand --myflag
-->

### PR Checklist

- [ ] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
- [ ] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Only render essential content.
- [ ] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
- [ ] Run `make gen/screenshot` if the root command output changes.
- [ ] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
