### PR TITLE
Add -r name=id relationship flag to api and create

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260819-161936.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260819-161936.yaml
@@ -1,0 +1,3 @@
+kind: ENHANCEMENTS
+body: "Added a `-r name=id` flag to `api` and `create` for setting JSON:API relationships without a full request body. The relationship's linkage type is inferred from the schema (e.g. `-r project=prj-...` links to type `projects`); ambiguous or unknown relationships can be pinned with `-r name:type=id`, and to-many relationships accept comma-separated ids"
+time: 2026-08-19T16:19:36.000000-04:00

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -466,11 +466,10 @@ func RunAPI(ctx context.Context, opts *Opts) error {
 		if opts.Client != nil && opts.Client.BaseURL != nil {
 			specPath = strings.TrimPrefix(specPath, strings.TrimRight(opts.Client.BaseURL.Path, "/"))
 		}
-		linkages, haveSchema = relationshipLinkages(oas, specPath)
-		if haveSchema {
-			names := make([]string, 0, len(linkages))
-			for name := range linkages {
-				names = append(names, name)
+		if linkages, haveSchema = relationshipLinkages(oas, specPath); haveSchema {
+			names := make([]string, len(linkages))
+			for i, name := range linkages {
+				names[i] = name
 			}
 			logger.Debug("resolved relationship linkages from schema", "path", specPath, "relationships", names)
 		} else {

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -467,6 +467,17 @@ func RunAPI(ctx context.Context, opts *Opts) error {
 			specPath = strings.TrimPrefix(specPath, strings.TrimRight(opts.Client.BaseURL.Path, "/"))
 		}
 		linkages, haveSchema = relationshipLinkages(oas, specPath)
+		if haveSchema {
+			names := make([]string, 0, len(linkages))
+			for name := range linkages {
+				names = append(names, name)
+			}
+			logger.Debug("resolved relationship linkages from schema", "path", specPath, "relationships", names)
+		} else {
+			// Not fatal: the request can still be built if every -r carries an
+			// explicit name:type=id. Otherwise buildRelationships returns a clear error.
+			logger.Debug("no relationship linkages resolved from schema; explicit types required for -r", "path", specPath)
+		}
 	}
 
 	// Construct a request

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -44,22 +44,27 @@ const (
 
 // Opts stores the options parsed from flags for the API command.
 type Opts struct {
-	IO           iostreams.IOStreams
-	Output       *format.Outputter
-	Client       *client.Client
-	Quiet        bool
-	DryRun       bool
-	Headers      []string
-	URL          *url.URL
-	Attributes   map[string]string
-	Query        map[string]string
-	PathParams   map[string]string
-	InputRequest string
-	Method       string
-	ResourceType string
-	All          bool
-	PageSize     int
-	PageNumber   int
+	IO            iostreams.IOStreams
+	Output        *format.Outputter
+	Client        *client.Client
+	Quiet         bool
+	DryRun        bool
+	Headers       []string
+	URL           *url.URL
+	Attributes    map[string]string
+	Relationships map[string]string
+	Query         map[string]string
+	PathParams    map[string]string
+	InputRequest  string
+	Method        string
+	ResourceType  string
+	All           bool
+	PageSize      int
+	PageNumber    int
+
+	// Schema, when set, is consulted to infer relationship linkage types and
+	// cardinality for -r. Nil falls back to the embedded spec.
+	Schema openapi.Schema
 
 	// Authorizer, when set, can permit a noninteractive DELETE based on an
 	// active exec session. Nil in tests that don't exercise session behavior.
@@ -70,13 +75,14 @@ type Opts struct {
 // maps/slices initialized to empty values.
 func NewOpts(io iostreams.IOStreams, output *format.Outputter, apiClient *client.Client) *Opts {
 	return &Opts{
-		IO:         io,
-		Output:     output,
-		Client:     apiClient,
-		Headers:    []string{},
-		Attributes: map[string]string{},
-		Query:      map[string]string{},
-		PathParams: map[string]string{},
+		IO:            io,
+		Output:        output,
+		Client:        apiClient,
+		Headers:       []string{},
+		Attributes:    map[string]string{},
+		Relationships: map[string]string{},
+		Query:         map[string]string{},
+		PathParams:    map[string]string{},
 	}
 }
 
@@ -173,6 +179,14 @@ func NewCmdAPI(inv *cmd.Invocation) *cmd.Command {
 					Value:        flagvalue.SimpleMap(nil, &opts.Attributes),
 				},
 				{
+					Name:         "relationship",
+					Shorthand:    "r",
+					DisplayValue: "NAME=ID",
+					Description:  "Relationship for JSON:API request bodies as name=id (repeatable). Implies POST method. The linkage type is inferred from the schema; override an unresolved one with name:type=id. Comma-separate ids for to-many relationships.",
+					Repeatable:   true,
+					Value:        flagvalue.SimpleMap(nil, &opts.Relationships),
+				},
+				{
 					Name:         "field",
 					Shorthand:    "f",
 					DisplayValue: "KEY=VALUE",
@@ -206,6 +220,10 @@ func NewCmdAPI(inv *cmd.Invocation) *cmd.Command {
 			{
 				Preamble: "Create a project using attributes",
 				Command:  heredoc.New(inv.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s api /projects -a name=myproject`, version.Name),
+			},
+			{
+				Preamble: "Create a workspace in a project (relationship type inferred from the schema)",
+				Command:  heredoc.New(inv.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s api /organizations/{organization}/workspaces -a name=foo -r project=prj-12dff4673ab9`, version.Name),
 			},
 			{
 				Preamble: "Add remote state consumer",
@@ -270,6 +288,7 @@ func NewCmdAPI(inv *cmd.Invocation) *cmd.Command {
 
 			opts.URL = resolvedURL
 			opts.Client = apiClient
+			opts.Schema = oas
 			opts.Quiet = inv.IsQuiet()
 			opts.DryRun = inv.IsDryRun()
 
@@ -431,13 +450,32 @@ func RunAPI(ctx context.Context, opts *Opts) error {
 
 	opts.URL.RawQuery = query.Encode()
 
+	// Resolve relationship linkage types and cardinality from the schema. The
+	// embedded spec is used when no schema was injected (e.g. by the create
+	// command or tests).
+	var linkages map[string]linkage
+	var haveSchema bool
+	if len(opts.Relationships) > 0 {
+		oas := opts.Schema
+		if oas == nil {
+			oas = openapi.LoadEmbeddedSchema()
+		}
+		// Spec paths are relative to the API version base (e.g. /api/v2), which
+		// the resolved request URL carries as a prefix; trim it before matching.
+		specPath := opts.URL.Path
+		if opts.Client != nil && opts.Client.BaseURL != nil {
+			specPath = strings.TrimPrefix(specPath, strings.TrimRight(opts.Client.BaseURL.Path, "/"))
+		}
+		linkages, haveSchema = relationshipLinkages(oas, specPath)
+	}
+
 	// Construct a request
-	body, contentType, err := buildRequestBody(opts.URL.Path, opts.InputRequest, opts.Attributes, opts.ResourceType, opts.IO.In())
+	body, contentType, err := buildRequestBody(opts.URL.Path, opts.InputRequest, opts.Attributes, opts.Relationships, opts.ResourceType, linkages, haveSchema, opts.IO.In())
 	if err != nil {
 		return err
 	}
 
-	method := inferMethod(opts.Method, len(opts.Attributes) > 0, opts.InputRequest != "")
+	method := inferMethod(opts.Method, len(opts.Attributes) > 0 || len(opts.Relationships) > 0, opts.InputRequest != "")
 
 	requestHeaders, err := parseHeaders(opts.Headers)
 	if err != nil {
@@ -628,7 +666,7 @@ func parseTypedValue(raw string) any {
 	return raw
 }
 
-func buildRequestBody(path, input string, attrs map[string]string, resourceType string, stdin io.Reader) ([]byte, string, error) {
+func buildRequestBody(path, input string, attrs, rels map[string]string, resourceType string, linkages map[string]linkage, haveSchema bool, stdin io.Reader) ([]byte, string, error) {
 	if input != "" {
 		var data []byte
 		var err error
@@ -645,7 +683,7 @@ func buildRequestBody(path, input string, attrs map[string]string, resourceType 
 		return data, "application/vnd.api+json", nil
 	}
 
-	if len(attrs) == 0 {
+	if len(attrs) == 0 && len(rels) == 0 {
 		return nil, "", nil
 	}
 
@@ -656,19 +694,25 @@ func buildRequestBody(path, input string, attrs map[string]string, resourceType 
 		return nil, "", errors.New("could not infer resource type from path; use --type")
 	}
 
-	attributes := make(map[string]any, len(attrs))
-	for key, value := range attrs {
-		attributes[key] = parseTypedValue(value)
+	data := map[string]any{"type": resourceType}
+
+	if len(attrs) > 0 {
+		attributes := make(map[string]any, len(attrs))
+		for key, value := range attrs {
+			attributes[key] = parseTypedValue(value)
+		}
+		data["attributes"] = attributes
 	}
 
-	body := map[string]any{
-		"data": map[string]any{
-			"type":       resourceType,
-			"attributes": attributes,
-		},
+	if len(rels) > 0 {
+		relationships, err := buildRelationships(rels, linkages, haveSchema)
+		if err != nil {
+			return nil, "", err
+		}
+		data["relationships"] = relationships
 	}
 
-	encoded, err := json.Marshal(body)
+	encoded, err := json.Marshal(map[string]any{"data": data})
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/commands/api/api.go
+++ b/internal/commands/api/api.go
@@ -449,6 +449,7 @@ func RunAPI(ctx context.Context, opts *Opts) error {
 	}
 
 	opts.URL.RawQuery = query.Encode()
+	method := inferMethod(opts.Method, len(opts.Attributes) > 0 || len(opts.Relationships) > 0, opts.InputRequest != "")
 
 	// Resolve relationship linkage types and cardinality from the schema. The
 	// embedded spec is used when no schema was injected (e.g. by the create
@@ -466,17 +467,17 @@ func RunAPI(ctx context.Context, opts *Opts) error {
 		if opts.Client != nil && opts.Client.BaseURL != nil {
 			specPath = strings.TrimPrefix(specPath, strings.TrimRight(opts.Client.BaseURL.Path, "/"))
 		}
-		linkages, haveSchema = relationshipLinkages(oas, specPath)
+		linkages, haveSchema = relationshipLinkages(oas, method, specPath)
 		if haveSchema {
 			names := make([]string, 0, len(linkages))
 			for name := range linkages {
 				names = append(names, name)
 			}
-			logger.Debug("resolved relationship linkages from schema", "path", specPath, "relationships", names)
+			logger.Debug("resolved relationship linkages from schema", "method", method, "path", specPath, "relationships", names)
 		} else {
 			// Not fatal: the request can still be built if every -r carries an
 			// explicit name:type=id. Otherwise buildRelationships returns a clear error.
-			logger.Debug("no relationship linkages resolved from schema; explicit types required for -r", "path", specPath)
+			logger.Debug("no relationship linkages resolved from schema; explicit types required for -r", "method", method, "path", specPath)
 		}
 	}
 
@@ -485,8 +486,6 @@ func RunAPI(ctx context.Context, opts *Opts) error {
 	if err != nil {
 		return err
 	}
-
-	method := inferMethod(opts.Method, len(opts.Attributes) > 0 || len(opts.Relationships) > 0, opts.InputRequest != "")
 
 	requestHeaders, err := parseHeaders(opts.Headers)
 	if err != nil {

--- a/internal/commands/api/relationships.go
+++ b/internal/commands/api/relationships.go
@@ -15,19 +15,27 @@ import (
 
 // linkage describes a JSON:API relationship's linkage as declared by the
 // schema: the resource type its members point to, and whether it is to-many.
+//
+// Type is the single pinned linkage type, or "" when the schema allows several
+// (e.g. locked-by → users|teams|runs). Types always lists every candidate the
+// schema allows (one element when pinned); it drives the "pin a type" hint for
+// ambiguous relationships.
 type linkage struct {
 	Type   string
+	Types  []string
 	ToMany bool
 }
 
-// relationshipLinkages returns the relationships declared on the POST request
-// body for the operation whose templated path matches the concrete requestPath,
-// keyed by relationship name.
+// relationshipLinkages returns the settable relationships declared on the POST
+// request body for the operation whose templated path matches the concrete
+// requestPath, keyed by relationship name.
 //
-// A relationship is included only when the schema pins its linkage type to a
-// single value; links-only relationships (no data) and ambiguous ones (a type
-// enum with more than one member, e.g. locked-by → users|teams|runs) are
-// omitted so the caller falls back to requiring an explicit name:type=id.
+// Relationships whose linkage type the schema pins to a single value carry that
+// type; ambiguous ones (a type enum with more than one member, e.g. locked-by →
+// users|teams|runs) are included with an empty Type and their candidates in
+// Types, so the caller can tell the user a relationship is real-but-ambiguous
+// (pin a type) rather than unknown. Links-only relationships (no data) are
+// omitted, as they cannot be set via a linkage.
 //
 // ok is false when no schema was available, no POST operation matched the path,
 // or the operation declares no settable relationships.
@@ -66,16 +74,21 @@ func relationshipLinkages(oas openapi.Schema, requestPath string) (result map[st
 			toMany = true
 			target = data.Value.Items.Value
 		}
-
-		enum := schemaTypeEnum(target)
-		if len(enum) != 1 {
-			continue // zero → not a linkage; >1 → ambiguous, require explicit type
-		}
-		typ, isStr := enum[0].(string)
-		if !isStr || typ == "" {
+		if target == nil {
 			continue
 		}
-		out[name] = linkage{Type: typ, ToMany: toMany}
+
+		types := enumStrings(schemaTypeEnum(target))
+		switch len(types) {
+		case 0:
+			continue // no type constraint: not a resolvable linkage
+		case 1:
+			out[name] = linkage{Type: types[0], Types: types, ToMany: toMany}
+		default:
+			// Ambiguous: keep it (with an empty Type) so the caller requires an
+			// explicit name:type=id and can name the candidates.
+			out[name] = linkage{Types: types, ToMany: toMany}
+		}
 	}
 
 	if len(out) == 0 {
@@ -109,6 +122,11 @@ func requestBodyRelationships(op *openapi3.Operation) *openapi3.Schema {
 // "type" field, following allOf/oneOf composition to reach the identifier
 // schema. To-one linkages wrap the identifier in an allOf; to-many ones expose
 // it directly under the array items.
+//
+// oneOf branches are unioned rather than short-circuited: a relationship
+// modeled as oneOf:[{type:users},{type:teams}] must surface as >1 type so the
+// caller treats it as ambiguous instead of silently picking the first branch.
+// (No relationship in today's spec is modeled this way; this is defensive.)
 func schemaTypeEnum(s *openapi3.Schema) []any {
 	if s == nil {
 		return nil
@@ -123,14 +141,35 @@ func schemaTypeEnum(s *openapi3.Schema) []any {
 			}
 		}
 	}
+	var union []any
+	seen := make(map[string]bool)
 	for _, sub := range s.OneOf {
-		if sub.Value != nil {
-			if e := schemaTypeEnum(sub.Value); e != nil {
-				return e
+		if sub.Value == nil {
+			continue
+		}
+		for _, v := range schemaTypeEnum(sub.Value) {
+			if str, ok := v.(string); ok {
+				if seen[str] {
+					continue
+				}
+				seen[str] = true
 			}
+			union = append(union, v)
 		}
 	}
-	return nil
+	return union
+}
+
+// enumStrings keeps the non-empty string members of a "type" enum, discarding
+// any non-string or empty values.
+func enumStrings(enum []any) []string {
+	out := make([]string, 0, len(enum))
+	for _, v := range enum {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // matchTemplatePath returns the templated spec path whose shape matches the
@@ -176,20 +215,37 @@ func buildRelationships(rels map[string]string, linkages map[string]linkage, hav
 	}
 
 	out := make(map[string]any, len(rels))
+	seen := make(map[string]string, len(rels)) // relationship name -> raw flag key that set it
 	for rawKey, rawVal := range rels {
 		name, explicitType, _ := strings.Cut(rawKey, ":")
 		if name == "" {
 			return nil, fmt.Errorf("relationship name is empty in %q", rawKey)
 		}
+		if prev, dup := seen[name]; dup {
+			return nil, fmt.Errorf("relationship %q specified more than once (as %q and %q); provide it once", name, prev, rawKey)
+		}
+		seen[name] = rawKey
 
 		lk, known := linkages[name]
 
+		// Determine the linkage type. An explicit name:type=id override always
+		// wins; otherwise the schema must resolve the type unambiguously.
 		typ := explicitType
-		if typ == "" {
-			if !known {
-				return nil, unknownRelationshipError(name, linkages, haveSchema)
+		toManyKnown := false
+		var toMany bool
+		switch {
+		case typ != "":
+			// The schema still tells us the cardinality when it knows the
+			// relationship, even for an ambiguous or unpinned type.
+			if known {
+				toMany, toManyKnown = lk.ToMany, true
 			}
-			typ = lk.Type
+		case !known:
+			return nil, unknownRelationshipError(name, linkages, haveSchema)
+		case lk.Type == "":
+			return nil, ambiguousRelationshipError(name, lk.Types)
+		default:
+			typ, toMany, toManyKnown = lk.Type, lk.ToMany, true
 		}
 
 		ids := splitIDs(rawVal)
@@ -197,13 +253,9 @@ func buildRelationships(rels map[string]string, linkages map[string]linkage, hav
 			return nil, fmt.Errorf("relationship %q has no id", name)
 		}
 
-		// Cardinality comes from the schema when the relationship is known;
-		// otherwise infer it from the number of ids supplied.
-		var toMany bool
-		switch {
-		case known:
-			toMany = lk.ToMany
-		default:
+		// Cardinality comes from the schema when known; otherwise infer it from
+		// the number of ids supplied.
+		if !toManyKnown {
 			toMany = len(ids) > 1
 		}
 
@@ -241,9 +293,18 @@ func splitIDs(raw string) []string {
 	return ids
 }
 
-// unknownRelationshipError explains that a relationship name could not be
-// resolved, listing the valid names when a schema was consulted or pointing at
-// the explicit override when it was not.
+// ambiguousRelationshipError explains that a relationship is real but its
+// linkage type is not pinned by the schema, so the user must choose one.
+func ambiguousRelationshipError(name string, types []string) error {
+	sorted := append([]string(nil), types...)
+	sort.Strings(sorted)
+	return fmt.Errorf("relationship %q maps to multiple types (%s); pin one with -r %s:<type>=<id>",
+		name, strings.Join(sorted, ", "), name)
+}
+
+// unknownRelationshipError explains that a relationship name is not declared for
+// this endpoint, listing the valid names when a schema was consulted or pointing
+// at the explicit override when it was not.
 func unknownRelationshipError(name string, linkages map[string]linkage, haveSchema bool) error {
 	override := fmt.Sprintf("-r %s:<type>=<id>", name)
 	if !haveSchema || len(linkages) == 0 {

--- a/internal/commands/api/relationships.go
+++ b/internal/commands/api/relationships.go
@@ -26,9 +26,9 @@ type linkage struct {
 	ToMany bool
 }
 
-// relationshipLinkages returns the settable relationships declared on the POST
-// request body for the operation whose templated path matches the concrete
-// requestPath, keyed by relationship name.
+// relationshipLinkages returns the settable relationships declared on the
+// request body for the operation whose method and templated path match the
+// request, keyed by relationship name.
 //
 // Relationships whose linkage type the schema pins to a single value carry that
 // type; ambiguous ones (a type enum with more than one member, e.g. locked-by →
@@ -37,9 +37,9 @@ type linkage struct {
 // (pin a type) rather than unknown. Links-only relationships (no data) are
 // omitted, as they cannot be set via a linkage.
 //
-// ok is false when no schema was available, no POST operation matched the path,
-// or the operation declares no settable relationships.
-func relationshipLinkages(oas openapi.Schema, requestPath string) (result map[string]linkage, ok bool) {
+// ok is false when no schema was available, no operation matched the method and
+// path, or the operation declares no settable relationships.
+func relationshipLinkages(oas openapi.Schema, method, requestPath string) (result map[string]linkage, ok bool) {
 	if oas == nil {
 		return nil, false
 	}
@@ -50,10 +50,14 @@ func relationshipLinkages(oas openapi.Schema, requestPath string) (result map[st
 	}
 
 	pathItem, err := oas.PathByPath(tmpl)
-	if err != nil || pathItem.Post == nil {
+	if err != nil {
 		return nil, false
 	}
-	rels := requestBodyRelationships(pathItem.Post)
+	op := pathItem.Operations()[strings.ToUpper(method)]
+	if op == nil {
+		return nil, false
+	}
+	rels := requestBodyRelationships(op)
 	if rels == nil {
 		return nil, false
 	}

--- a/internal/commands/api/relationships.go
+++ b/internal/commands/api/relationships.go
@@ -1,0 +1,260 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/hashicorp/tfctl-cli/internal/pkg/openapi"
+)
+
+// linkage describes a JSON:API relationship's linkage as declared by the
+// schema: the resource type its members point to, and whether it is to-many.
+type linkage struct {
+	Type   string
+	ToMany bool
+}
+
+// relationshipLinkages returns the relationships declared on the POST request
+// body for the operation whose templated path matches the concrete requestPath,
+// keyed by relationship name.
+//
+// A relationship is included only when the schema pins its linkage type to a
+// single value; links-only relationships (no data) and ambiguous ones (a type
+// enum with more than one member, e.g. locked-by → users|teams|runs) are
+// omitted so the caller falls back to requiring an explicit name:type=id.
+//
+// ok is false when no schema was available, no POST operation matched the path,
+// or the operation declares no settable relationships.
+func relationshipLinkages(oas openapi.Schema, requestPath string) (result map[string]linkage, ok bool) {
+	if oas == nil {
+		return nil, false
+	}
+
+	tmpl := matchTemplatePath(oas, requestPath)
+	if tmpl == "" {
+		return nil, false
+	}
+
+	pathItem, err := oas.PathByPath(tmpl)
+	if err != nil || pathItem.Post == nil {
+		return nil, false
+	}
+	rels := requestBodyRelationships(pathItem.Post)
+	if rels == nil {
+		return nil, false
+	}
+
+	out := make(map[string]linkage, len(rels.Properties))
+	for name, ref := range rels.Properties {
+		if ref.Value == nil {
+			continue
+		}
+		data := ref.Value.Properties["data"]
+		if data == nil || data.Value == nil {
+			continue // links-only relationship: not settable via a linkage
+		}
+
+		target := data.Value
+		toMany := false
+		if data.Value.Items != nil {
+			toMany = true
+			target = data.Value.Items.Value
+		}
+
+		enum := schemaTypeEnum(target)
+		if len(enum) != 1 {
+			continue // zero → not a linkage; >1 → ambiguous, require explicit type
+		}
+		typ, isStr := enum[0].(string)
+		if !isStr || typ == "" {
+			continue
+		}
+		out[name] = linkage{Type: typ, ToMany: toMany}
+	}
+
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+// requestBodyRelationships returns the schema of the JSON:API "relationships"
+// object in an operation's request body, or nil if it has none.
+func requestBodyRelationships(op *openapi3.Operation) *openapi3.Schema {
+	if op.RequestBody == nil || op.RequestBody.Value == nil {
+		return nil
+	}
+	media := op.RequestBody.Value.Content["application/vnd.api+json"]
+	if media == nil || media.Schema == nil || media.Schema.Value == nil {
+		return nil
+	}
+	data := media.Schema.Value.Properties["data"]
+	if data == nil || data.Value == nil {
+		return nil
+	}
+	rels := data.Value.Properties["relationships"]
+	if rels == nil || rels.Value == nil {
+		return nil
+	}
+	return rels.Value
+}
+
+// schemaTypeEnum returns the enum values constraining a JSON:API identifier's
+// "type" field, following allOf/oneOf composition to reach the identifier
+// schema. To-one linkages wrap the identifier in an allOf; to-many ones expose
+// it directly under the array items.
+func schemaTypeEnum(s *openapi3.Schema) []any {
+	if s == nil {
+		return nil
+	}
+	if p, ok := s.Properties["type"]; ok && p.Value != nil && len(p.Value.Enum) > 0 {
+		return p.Value.Enum
+	}
+	for _, sub := range s.AllOf {
+		if sub.Value != nil {
+			if e := schemaTypeEnum(sub.Value); e != nil {
+				return e
+			}
+		}
+	}
+	for _, sub := range s.OneOf {
+		if sub.Value != nil {
+			if e := schemaTypeEnum(sub.Value); e != nil {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+// matchTemplatePath returns the templated spec path whose shape matches the
+// given concrete path (e.g. /organizations/acme/workspaces matches
+// /organizations/{organization_name}/workspaces), or "" if none matches. A spec
+// segment matches when it equals the concrete segment or is a {placeholder}.
+func matchTemplatePath(oas openapi.Schema, concrete string) string {
+	want := splitPathSegments(concrete)
+	for _, key := range oas.Paths().Keys() {
+		have := splitPathSegments(key)
+		if len(have) != len(want) {
+			continue
+		}
+		matched := true
+		for i, seg := range have {
+			if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {
+				continue
+			}
+			if seg != want[i] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return key
+		}
+	}
+	return ""
+}
+
+func splitPathSegments(p string) []string {
+	return strings.FieldsFunc(strings.Trim(p, "/"), func(r rune) bool { return r == '/' })
+}
+
+// buildRelationships constructs the JSON:API "relationships" object from the -r
+// flag values. Each flag key is a relationship name, optionally suffixed with an
+// explicit ":type" override (name:type=id); without the override the linkage
+// type and cardinality are resolved from the schema. Ids for a to-many
+// relationship are comma-separated.
+func buildRelationships(rels map[string]string, linkages map[string]linkage, haveSchema bool) (map[string]any, error) {
+	if len(rels) == 0 {
+		return nil, nil
+	}
+
+	out := make(map[string]any, len(rels))
+	for rawKey, rawVal := range rels {
+		name, explicitType, _ := strings.Cut(rawKey, ":")
+		if name == "" {
+			return nil, fmt.Errorf("relationship name is empty in %q", rawKey)
+		}
+
+		lk, known := linkages[name]
+
+		typ := explicitType
+		if typ == "" {
+			if !known {
+				return nil, unknownRelationshipError(name, linkages, haveSchema)
+			}
+			typ = lk.Type
+		}
+
+		ids := splitIDs(rawVal)
+		if len(ids) == 0 {
+			return nil, fmt.Errorf("relationship %q has no id", name)
+		}
+
+		// Cardinality comes from the schema when the relationship is known;
+		// otherwise infer it from the number of ids supplied.
+		var toMany bool
+		switch {
+		case known:
+			toMany = lk.ToMany
+		default:
+			toMany = len(ids) > 1
+		}
+
+		if !toMany {
+			if len(ids) > 1 {
+				return nil, fmt.Errorf("relationship %q is to-one but got %d ids: %s", name, len(ids), strings.Join(ids, ", "))
+			}
+			out[name] = map[string]any{"data": identifier(typ, ids[0])}
+			continue
+		}
+
+		data := make([]any, 0, len(ids))
+		for _, id := range ids {
+			data = append(data, identifier(typ, id))
+		}
+		out[name] = map[string]any{"data": data}
+	}
+	return out, nil
+}
+
+func identifier(typ, id string) map[string]any {
+	return map[string]any{"type": typ, "id": id}
+}
+
+// splitIDs splits a comma-separated id list, trimming whitespace and dropping
+// empty entries.
+func splitIDs(raw string) []string {
+	parts := strings.Split(raw, ",")
+	ids := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if id := strings.TrimSpace(p); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// unknownRelationshipError explains that a relationship name could not be
+// resolved, listing the valid names when a schema was consulted or pointing at
+// the explicit override when it was not.
+func unknownRelationshipError(name string, linkages map[string]linkage, haveSchema bool) error {
+	override := fmt.Sprintf("-r %s:<type>=<id>", name)
+	if !haveSchema || len(linkages) == 0 {
+		return fmt.Errorf("could not infer the resource type for relationship %q; specify it explicitly with %s", name, override)
+	}
+
+	names := make([]string, 0, len(linkages))
+	for n := range linkages {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return fmt.Errorf("unknown relationship %q for this endpoint; valid relationships: %s (or override with %s)",
+		name, strings.Join(names, ", "), override)
+}

--- a/internal/commands/api/relationships_test.go
+++ b/internal/commands/api/relationships_test.go
@@ -41,16 +41,21 @@ func TestRelationshipLinkages_FromEmbeddedSchema(t *testing.T) {
 
 	// To-one linkage: the key differs from the type, which is exactly why we
 	// read the type from the schema rather than the flag key.
-	require.Equal(t, linkage{Type: "projects", ToMany: false}, linkages["project"])
-	require.Equal(t, linkage{Type: "agent-pools", ToMany: false}, linkages["agent-pool"])
+	require.Equal(t, linkage{Type: "projects", Types: []string{"projects"}, ToMany: false}, linkages["project"])
+	require.Equal(t, linkage{Type: "agent-pools", Types: []string{"agent-pools"}, ToMany: false}, linkages["agent-pool"])
 
 	// To-many linkage.
-	require.Equal(t, linkage{Type: "workspace-outputs", ToMany: true}, linkages["outputs"])
+	require.Equal(t, linkage{Type: "workspace-outputs", Types: []string{"workspace-outputs"}, ToMany: true}, linkages["outputs"])
 
-	// Ambiguous (type enum has several members, e.g. users|teams|runs) and
-	// links-only relationships are omitted so the caller requires an explicit type.
-	_, ambiguous := linkages["locked-by"]
-	require.False(t, ambiguous, "ambiguous relationship should be omitted")
+	// Ambiguous (type enum has several members, e.g. users|teams|runs): kept
+	// with an empty Type so the caller requires an explicit type, but its
+	// candidates are preserved to name them in the error.
+	lockedBy, ok := linkages["locked-by"]
+	require.True(t, ok, "ambiguous relationship should still be reported")
+	require.Empty(t, lockedBy.Type, "ambiguous relationship has no single pinned type")
+	require.Greater(t, len(lockedBy.Types), 1, "ambiguous relationship lists its candidates")
+
+	// Links-only relationships (no data linkage) are omitted.
 	_, linksOnly := linkages["remote-state-consumers"]
 	require.False(t, linksOnly, "links-only relationship should be omitted")
 }
@@ -102,6 +107,30 @@ func TestBuildRelationships(t *testing.T) {
 		require.Equal(t, map[string]any{
 			"locked-by": map[string]any{"data": map[string]any{"type": "users", "id": "user-1"}},
 		}, got)
+	})
+
+	t.Run("ambiguous relationship names its candidate types", func(t *testing.T) {
+		t.Parallel()
+		ambiguous := map[string]linkage{
+			"locked-by": {Types: []string{"users", "teams", "runs"}, ToMany: false},
+		}
+		_, err := buildRelationships(map[string]string{"locked-by": "user-1"}, ambiguous, true)
+		require.Error(t, err)
+		// Distinct from the "unknown relationship" message: it names the types
+		// and points at the explicit override.
+		assert.Contains(t, err.Error(), "maps to multiple types")
+		assert.Contains(t, err.Error(), "runs, teams, users") // sorted
+		assert.Contains(t, err.Error(), "locked-by:<type>=<id>")
+	})
+
+	t.Run("same relationship specified twice errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildRelationships(
+			map[string]string{"project": "prj-1", "project:projects": "prj-2"},
+			linkages, true,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `relationship "project" specified more than once`)
 	})
 
 	t.Run("unknown relationship with schema lists valid names", func(t *testing.T) {

--- a/internal/commands/api/relationships_test.go
+++ b/internal/commands/api/relationships_test.go
@@ -5,7 +5,11 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"slices"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,6 +107,93 @@ func TestRelationshipLinkages_FromEmbeddedSchema(t *testing.T) {
 	// Links-only relationships (no data linkage) are omitted.
 	_, linksOnly := linkages["remote-state-consumers"]
 	require.False(t, linksOnly, "links-only relationship should be omitted")
+}
+
+// DashR relies on the OpenAPI spec for relationship inference. Scan the full
+// embedded spec so a new relationship shape cannot silently produce an
+// incorrect request or fail only when a user invokes the command.
+func TestRelationshipLinkages_EmbeddedSchemaShapesAreSupported(t *testing.T) {
+	t.Parallel()
+
+	oas := openapi.LoadEmbeddedSchema()
+	var unsupported []string
+	settableRelationships := 0
+
+	for _, operation := range oas.Operations() {
+		if operation.RequestBody == nil || operation.RequestBody.Value == nil {
+			continue
+		}
+		media := operation.RequestBody.Value.Content["application/vnd.api+json"]
+		if media == nil || media.Schema == nil || media.Schema.Value == nil {
+			continue
+		}
+		data := media.Schema.Value.Properties["data"]
+		if data == nil || data.Value == nil {
+			continue
+		}
+		rels := data.Value.Properties["relationships"]
+		if rels == nil || rels.Value == nil {
+			continue
+		}
+
+		linkages, _ := relationshipLinkages(oas, operation.Method, operation.Path)
+		for name, relationshipRef := range rels.Value.Properties {
+			location := fmt.Sprintf("%s %s (%s) relationship %q", operation.Method, operation.Path, operation.OperationID, name)
+			if relationshipRef == nil || relationshipRef.Value == nil {
+				unsupported = append(unsupported, location+": relationship schema is unresolved")
+				continue
+			}
+
+			dataRef, hasData := relationshipRef.Value.Properties["data"]
+			if !hasData {
+				continue // Links-only relationships are not settable with -r.
+			}
+			settableRelationships++
+			if dataRef == nil || dataRef.Value == nil {
+				unsupported = append(unsupported, location+": data schema is unresolved")
+				continue
+			}
+
+			target := dataRef.Value
+			toMany := dataRef.Value.Items != nil
+			if toMany {
+				if dataRef.Value.Items.Value == nil {
+					unsupported = append(unsupported, location+": array data has no resolved item schema")
+					continue
+				}
+				target = dataRef.Value.Items.Value
+			} else if dataRef.Value.Type != nil && dataRef.Value.Type.Is("array") {
+				unsupported = append(unsupported, location+": array data has no item schema")
+				continue
+			}
+
+			types := enumStrings(schemaTypeEnum(target))
+			if len(types) == 0 {
+				unsupported = append(unsupported, location+": identifier type has no supported non-empty string enum")
+				continue
+			}
+
+			got, ok := linkages[name]
+			if !ok {
+				unsupported = append(unsupported, location+": DashR did not discover the relationship")
+				continue
+			}
+			gotTypes := append([]string(nil), got.Types...)
+			wantTypes := append([]string(nil), types...)
+			sort.Strings(gotTypes)
+			sort.Strings(wantTypes)
+			if !slices.Equal(gotTypes, wantTypes) || got.ToMany != toMany {
+				unsupported = append(unsupported, fmt.Sprintf("%s: DashR inferred types %v and to-many %t; want types %v and to-many %t", location, got.Types, got.ToMany, types, toMany))
+			}
+		}
+	}
+
+	require.NotZero(t, settableRelationships, "expected the embedded OpenAPI spec to contain settable relationships")
+	sort.Strings(unsupported)
+	require.Empty(t, unsupported,
+		"the OpenAPI spec contains relationship shapes that DashR does not support; update DashR or make the relationship definition unambiguous:\n%s",
+		strings.Join(unsupported, "\n"),
+	)
 }
 
 func TestRelationshipLinkages_UsesHTTPMethod(t *testing.T) {

--- a/internal/commands/api/relationships_test.go
+++ b/internal/commands/api/relationships_test.go
@@ -36,7 +36,7 @@ func TestMatchTemplatePath(t *testing.T) {
 func TestRelationshipLinkages_FromEmbeddedSchema(t *testing.T) {
 	t.Parallel()
 
-	linkages, ok := relationshipLinkages(openapi.LoadEmbeddedSchema(), "/organizations/acme/workspaces")
+	linkages, ok := relationshipLinkages(openapi.LoadEmbeddedSchema(), http.MethodPost, "/organizations/acme/workspaces")
 	require.True(t, ok)
 
 	// To-one linkage: the key differs from the type, which is exactly why we
@@ -60,13 +60,28 @@ func TestRelationshipLinkages_FromEmbeddedSchema(t *testing.T) {
 	require.False(t, linksOnly, "links-only relationship should be omitted")
 }
 
+func TestRelationshipLinkages_UsesHTTPMethod(t *testing.T) {
+	t.Parallel()
+
+	linkages, ok := relationshipLinkages(openapi.LoadEmbeddedSchema(), http.MethodPatch, "/workspaces/ws-1")
+	require.True(t, ok)
+	require.Equal(t, linkage{Type: "projects", Types: []string{"projects"}, ToMany: false}, linkages["project"])
+
+	linkages, ok = relationshipLinkages(openapi.LoadEmbeddedSchema(), http.MethodPut, "/organizations/acme")
+	require.True(t, ok)
+	require.Equal(t, linkage{Type: "projects", Types: []string{"projects"}, ToMany: false}, linkages["default-project"])
+
+	_, ok = relationshipLinkages(openapi.LoadEmbeddedSchema(), http.MethodPost, "/workspaces/ws-1")
+	require.False(t, ok)
+}
+
 func TestRelationshipLinkages_NoSchemaOrNoMatch(t *testing.T) {
 	t.Parallel()
 
-	_, ok := relationshipLinkages(nil, "/organizations/acme/workspaces")
+	_, ok := relationshipLinkages(nil, http.MethodPost, "/organizations/acme/workspaces")
 	require.False(t, ok)
 
-	_, ok = relationshipLinkages(openapi.LoadEmbeddedSchema(), "/nope/not/real")
+	_, ok = relationshipLinkages(openapi.LoadEmbeddedSchema(), http.MethodPost, "/nope/not/real")
 	require.False(t, ok)
 }
 
@@ -240,4 +255,37 @@ func TestRunAPI_RelationshipOnlyBody(t *testing.T) {
 	_, hasAttrs := data["attributes"]
 	require.False(t, hasAttrs, "no attributes key expected for relationship-only body")
 	require.Contains(t, data, "relationships")
+}
+
+func TestRunAPI_RelationshipInfersTypeForPatch(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"PATCH /api/v2/workspaces/ws-1": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+				"data": map[string]any{"id": "ws-1", "type": "workspaces"},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := RunAPI(context.Background(), newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/workspaces/ws-1")
+		opts.Method = http.MethodPatch
+		opts.Relationships = map[string]string{"project": "prj-1"}
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodPatch, recorder.Last().Method)
+	assertJSONBodyEqual(t, map[string]any{
+		"data": map[string]any{
+			"type": "workspaces",
+			"relationships": map[string]any{
+				"project": map[string]any{
+					"data": map[string]any{"type": "projects", "id": "prj-1"},
+				},
+			},
+		},
+	}, recorder.Last().JSONBody(t))
 }

--- a/internal/commands/api/relationships_test.go
+++ b/internal/commands/api/relationships_test.go
@@ -1,0 +1,214 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/tfctl-cli/internal/pkg/iostreams"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/openapi"
+)
+
+func TestMatchTemplatePath(t *testing.T) {
+	t.Parallel()
+
+	oas := openapi.LoadEmbeddedSchema()
+
+	require.Equal(t,
+		"/organizations/{organization_name}/workspaces",
+		matchTemplatePath(oas, "/organizations/acme/workspaces"),
+	)
+	// A placeholder segment matches any concrete value.
+	require.Equal(t,
+		"/organizations/{organization_name}",
+		matchTemplatePath(oas, "/organizations/acme"),
+	)
+	// A path the spec does not describe.
+	require.Equal(t, "", matchTemplatePath(oas, "/nope/not/a/real/path"))
+}
+
+func TestRelationshipLinkages_FromEmbeddedSchema(t *testing.T) {
+	t.Parallel()
+
+	linkages, ok := relationshipLinkages(openapi.LoadEmbeddedSchema(), "/organizations/acme/workspaces")
+	require.True(t, ok)
+
+	// To-one linkage: the key differs from the type, which is exactly why we
+	// read the type from the schema rather than the flag key.
+	require.Equal(t, linkage{Type: "projects", ToMany: false}, linkages["project"])
+	require.Equal(t, linkage{Type: "agent-pools", ToMany: false}, linkages["agent-pool"])
+
+	// To-many linkage.
+	require.Equal(t, linkage{Type: "workspace-outputs", ToMany: true}, linkages["outputs"])
+
+	// Ambiguous (type enum has several members, e.g. users|teams|runs) and
+	// links-only relationships are omitted so the caller requires an explicit type.
+	_, ambiguous := linkages["locked-by"]
+	require.False(t, ambiguous, "ambiguous relationship should be omitted")
+	_, linksOnly := linkages["remote-state-consumers"]
+	require.False(t, linksOnly, "links-only relationship should be omitted")
+}
+
+func TestRelationshipLinkages_NoSchemaOrNoMatch(t *testing.T) {
+	t.Parallel()
+
+	_, ok := relationshipLinkages(nil, "/organizations/acme/workspaces")
+	require.False(t, ok)
+
+	_, ok = relationshipLinkages(openapi.LoadEmbeddedSchema(), "/nope/not/real")
+	require.False(t, ok)
+}
+
+func TestBuildRelationships(t *testing.T) {
+	t.Parallel()
+
+	linkages := map[string]linkage{
+		"project": {Type: "projects", ToMany: false},
+		"outputs": {Type: "workspace-outputs", ToMany: true},
+	}
+
+	t.Run("schema-inferred to-one", func(t *testing.T) {
+		t.Parallel()
+		got, err := buildRelationships(map[string]string{"project": "prj-1"}, linkages, true)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"project": map[string]any{"data": map[string]any{"type": "projects", "id": "prj-1"}},
+		}, got)
+	})
+
+	t.Run("schema-inferred to-many, comma-separated ids", func(t *testing.T) {
+		t.Parallel()
+		got, err := buildRelationships(map[string]string{"outputs": "wsout-1, wsout-2"}, linkages, true)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"outputs": map[string]any{"data": []any{
+				map[string]any{"type": "workspace-outputs", "id": "wsout-1"},
+				map[string]any{"type": "workspace-outputs", "id": "wsout-2"},
+			}},
+		}, got)
+	})
+
+	t.Run("explicit name:type=id override", func(t *testing.T) {
+		t.Parallel()
+		// "locked-by" is ambiguous in the schema, so the user pins the type.
+		got, err := buildRelationships(map[string]string{"locked-by:users": "user-1"}, linkages, true)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"locked-by": map[string]any{"data": map[string]any{"type": "users", "id": "user-1"}},
+		}, got)
+	})
+
+	t.Run("unknown relationship with schema lists valid names", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildRelationships(map[string]string{"projects": "prj-1"}, linkages, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown relationship "projects"`)
+		assert.Contains(t, err.Error(), "valid relationships:")
+		assert.Contains(t, err.Error(), "project")
+	})
+
+	t.Run("unknown relationship without schema advises explicit type", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildRelationships(map[string]string{"whatever": "x-1"}, nil, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "could not infer the resource type")
+		assert.Contains(t, err.Error(), "whatever:<type>=<id>")
+	})
+
+	t.Run("to-one with multiple ids errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildRelationships(map[string]string{"project": "prj-1,prj-2"}, linkages, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is to-one but got 2 ids")
+	})
+
+	t.Run("empty id errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildRelationships(map[string]string{"project": "  "}, linkages, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has no id")
+	})
+
+	t.Run("unknown relationship with explicit type and multiple ids infers to-many", func(t *testing.T) {
+		t.Parallel()
+		got, err := buildRelationships(map[string]string{"widgets:widgets": "w-1,w-2"}, nil, false)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{
+			"widgets": map[string]any{"data": []any{
+				map[string]any{"type": "widgets", "id": "w-1"},
+				map[string]any{"type": "widgets", "id": "w-2"},
+			}},
+		}, got)
+	})
+}
+
+// TestRunAPI_RelationshipInfersTypeAndPost exercises the full path: -r implies
+// POST, and the linkage type is read from the embedded schema for the matched
+// operation.
+func TestRunAPI_RelationshipInfersTypeAndPost(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"POST /api/v2/organizations/acme/workspaces": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{"id": "ws-1", "type": "workspaces"},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := RunAPI(context.Background(), newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/organizations/acme/workspaces")
+		opts.Attributes = map[string]string{"name": "foo"}
+		opts.Relationships = map[string]string{"project": "prj-12dff4673ab9"}
+	}))
+	require.NoError(t, err)
+
+	require.Equal(t, "POST", recorder.Last().Method)
+	assertJSONBodyEqual(t, map[string]any{
+		"data": map[string]any{
+			"type":       "workspaces",
+			"attributes": map[string]any{"name": "foo"},
+			"relationships": map[string]any{
+				"project": map[string]any{
+					"data": map[string]any{"type": "projects", "id": "prj-12dff4673ab9"},
+				},
+			},
+		},
+	}, recorder.Last().JSONBody(t))
+}
+
+// TestRunAPI_RelationshipOnlyBody confirms a relationship-only request still
+// produces a valid data envelope (no attributes key).
+func TestRunAPI_RelationshipOnlyBody(t *testing.T) {
+	t.Parallel()
+
+	server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+		"POST /api/v2/organizations/acme/workspaces": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSONAPIResponse(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{"id": "ws-1", "type": "workspaces"},
+			})
+		},
+	})
+	defer server.Close()
+
+	io := iostreams.Test()
+	err := RunAPI(context.Background(), newTestOpts(t, server.URL, io, func(opts *Opts) {
+		opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/organizations/acme/workspaces")
+		opts.Relationships = map[string]string{"project": "prj-1"}
+	}))
+	require.NoError(t, err)
+
+	body := recorder.Last().JSONBody(t)
+	data := nestedMap(t, body, "data")
+	_, hasAttrs := data["attributes"]
+	require.False(t, hasAttrs, "no attributes key expected for relationship-only body")
+	require.Contains(t, data, "relationships")
+}

--- a/internal/commands/api/relationships_test.go
+++ b/internal/commands/api/relationships_test.go
@@ -15,6 +15,51 @@ import (
 	"github.com/hashicorp/tfctl-cli/internal/pkg/openapi"
 )
 
+const relationshipTestSchema = `{
+  "openapi": "3.0.0",
+  "info": {"title": "relationship test", "version": "1"},
+  "paths": {
+    "/custom-resources": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "relationships": {
+                        "type": "object",
+                        "properties": {
+                          "owner": {
+                            "type": "object",
+                            "properties": {
+                              "data": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {"type": "string", "enum": ["custom-owners"]},
+                                  "id": {"type": "string"}
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`
+
 func TestMatchTemplatePath(t *testing.T) {
 	t.Parallel()
 
@@ -288,4 +333,59 @@ func TestRunAPI_RelationshipInfersTypeForPatch(t *testing.T) {
 			},
 		},
 	}, recorder.Last().JSONBody(t))
+}
+
+func TestRunAPI_RelationshipSchemaSelection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses injected schema", func(t *testing.T) {
+		t.Parallel()
+
+		schema, err := openapi.NewFromData([]byte(relationshipTestSchema))
+		require.NoError(t, err)
+		server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+			"POST /api/v2/custom-resources": func(w http.ResponseWriter, _ *http.Request) {
+				writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+					"data": map[string]any{"id": "custom-1", "type": "custom-resources"},
+				})
+			},
+		})
+		defer server.Close()
+
+		err = RunAPI(context.Background(), newTestOpts(t, server.URL, iostreams.Test(), func(opts *Opts) {
+			opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/custom-resources")
+			opts.Schema = schema
+			opts.Relationships = map[string]string{"owner": "owner-1"}
+		}))
+		require.NoError(t, err)
+
+		data := nestedMap(t, recorder.Last().JSONBody(t), "data")
+		relationships := nestedMap(t, data, "relationships")
+		owner := nestedMap(t, relationships, "owner")
+		require.Equal(t, map[string]any{"type": "custom-owners", "id": "owner-1"}, owner["data"])
+	})
+
+	t.Run("allows explicit type without endpoint schema", func(t *testing.T) {
+		t.Parallel()
+
+		server, recorder := newAPITestServer(map[string]http.HandlerFunc{
+			"POST /api/v2/custom-resources": func(w http.ResponseWriter, _ *http.Request) {
+				writeJSONAPIResponse(w, http.StatusOK, map[string]any{
+					"data": map[string]any{"id": "custom-1", "type": "custom-resources"},
+				})
+			},
+		})
+		defer server.Close()
+
+		err := RunAPI(context.Background(), newTestOpts(t, server.URL, iostreams.Test(), func(opts *Opts) {
+			opts.URL = mustResolveTestURL(t, opts.Client.BaseURL.String(), "/custom-resources")
+			opts.Relationships = map[string]string{"owner:custom-owners": "owner-1"}
+		}))
+		require.NoError(t, err)
+
+		data := nestedMap(t, recorder.Last().JSONBody(t), "data")
+		relationships := nestedMap(t, data, "relationships")
+		owner := nestedMap(t, relationships, "owner")
+		require.Equal(t, map[string]any{"type": "custom-owners", "id": "owner-1"}, owner["data"])
+	})
 }

--- a/internal/commands/api/relationships_test.go
+++ b/internal/commands/api/relationships_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -115,6 +116,19 @@ func TestRelationshipLinkages_FromEmbeddedSchema(t *testing.T) {
 func TestRelationshipLinkages_EmbeddedSchemaShapesAreSupported(t *testing.T) {
 	t.Parallel()
 
+	type relationshipKey struct {
+		method string
+		path   string
+		name   string
+	}
+	// These relationships are inside a top-level data.oneOf. DashR does not yet
+	// traverse composed resource schemas to discover them.
+	knownExceptions := map[relationshipKey]struct{}{
+		{method: http.MethodPost, path: "/organizations/{organization_name}/oidc-configurations", name: "organization"}: {},
+		{method: http.MethodPatch, path: "/oidc-configurations/{oidc_configuration_id}", name: "organization"}:          {},
+	}
+	seenExceptions := make(map[relationshipKey]bool, len(knownExceptions))
+
 	oas := openapi.LoadEmbeddedSchema()
 	var unsupported []string
 	settableRelationships := 0
@@ -127,64 +141,74 @@ func TestRelationshipLinkages_EmbeddedSchemaShapesAreSupported(t *testing.T) {
 		if media == nil || media.Schema == nil || media.Schema.Value == nil {
 			continue
 		}
-		data := media.Schema.Value.Properties["data"]
-		if data == nil || data.Value == nil {
-			continue
-		}
-		rels := data.Value.Properties["relationships"]
-		if rels == nil || rels.Value == nil {
-			continue
-		}
 
 		linkages, _ := relationshipLinkages(oas, operation.Method, operation.Path)
-		for name, relationshipRef := range rels.Value.Properties {
-			location := fmt.Sprintf("%s %s (%s) relationship %q", operation.Method, operation.Path, operation.OperationID, name)
-			if relationshipRef == nil || relationshipRef.Value == nil {
-				unsupported = append(unsupported, location+": relationship schema is unresolved")
-				continue
-			}
+		for _, data := range composedPropertySchemas(media.Schema.Value, "data") {
+			for _, rels := range composedPropertySchemas(data, "relationships") {
+				for name, relationshipRef := range rels.Properties {
+					key := relationshipKey{method: operation.Method, path: operation.Path, name: name}
+					location := fmt.Sprintf("%s %s (%s) relationship %q", operation.Method, operation.Path, operation.OperationID, name)
+					if relationshipRef == nil || relationshipRef.Value == nil {
+						unsupported = append(unsupported, location+": relationship schema is unresolved")
+						continue
+					}
 
-			dataRef, hasData := relationshipRef.Value.Properties["data"]
-			if !hasData {
-				continue // Links-only relationships are not settable with -r.
-			}
-			settableRelationships++
-			if dataRef == nil || dataRef.Value == nil {
-				unsupported = append(unsupported, location+": data schema is unresolved")
-				continue
-			}
+					dataRef, hasData := relationshipRef.Value.Properties["data"]
+					if !hasData {
+						continue // Links-only relationships are not settable with -r.
+					}
+					settableRelationships++
+					if dataRef == nil || dataRef.Value == nil {
+						unsupported = append(unsupported, location+": data schema is unresolved")
+						continue
+					}
 
-			target := dataRef.Value
-			toMany := dataRef.Value.Items != nil
-			if toMany {
-				if dataRef.Value.Items.Value == nil {
-					unsupported = append(unsupported, location+": array data has no resolved item schema")
-					continue
+					target := dataRef.Value
+					toMany := dataRef.Value.Items != nil
+					if toMany {
+						if dataRef.Value.Items.Value == nil {
+							unsupported = append(unsupported, location+": array data has no resolved item schema")
+							continue
+						}
+						target = dataRef.Value.Items.Value
+					} else if dataRef.Value.Type != nil && dataRef.Value.Type.Is("array") {
+						unsupported = append(unsupported, location+": array data has no item schema")
+						continue
+					}
+
+					types := enumStrings(schemaTypeEnum(target))
+					if len(types) == 0 {
+						unsupported = append(unsupported, location+": identifier type has no supported non-empty string enum")
+						continue
+					}
+
+					got, ok := linkages[name]
+					if !ok {
+						if _, known := knownExceptions[key]; known {
+							seenExceptions[key] = true
+							continue
+						}
+						unsupported = append(unsupported, location+": DashR did not discover the relationship")
+						continue
+					}
+					gotTypes := append([]string(nil), got.Types...)
+					wantTypes := append([]string(nil), types...)
+					sort.Strings(gotTypes)
+					sort.Strings(wantTypes)
+					if !slices.Equal(gotTypes, wantTypes) || got.ToMany != toMany {
+						unsupported = append(unsupported, fmt.Sprintf("%s: DashR inferred types %v and to-many %t; want types %v and to-many %t", location, got.Types, got.ToMany, types, toMany))
+					}
 				}
-				target = dataRef.Value.Items.Value
-			} else if dataRef.Value.Type != nil && dataRef.Value.Type.Is("array") {
-				unsupported = append(unsupported, location+": array data has no item schema")
-				continue
 			}
+		}
+	}
 
-			types := enumStrings(schemaTypeEnum(target))
-			if len(types) == 0 {
-				unsupported = append(unsupported, location+": identifier type has no supported non-empty string enum")
-				continue
-			}
-
-			got, ok := linkages[name]
-			if !ok {
-				unsupported = append(unsupported, location+": DashR did not discover the relationship")
-				continue
-			}
-			gotTypes := append([]string(nil), got.Types...)
-			wantTypes := append([]string(nil), types...)
-			sort.Strings(gotTypes)
-			sort.Strings(wantTypes)
-			if !slices.Equal(gotTypes, wantTypes) || got.ToMany != toMany {
-				unsupported = append(unsupported, fmt.Sprintf("%s: DashR inferred types %v and to-many %t; want types %v and to-many %t", location, got.Types, got.ToMany, types, toMany))
-			}
+	for exception := range knownExceptions {
+		if !seenExceptions[exception] {
+			unsupported = append(unsupported, fmt.Sprintf(
+				"known exception %s %s relationship %q was not found; remove it from the exception list",
+				exception.method, exception.path, exception.name,
+			))
 		}
 	}
 
@@ -194,6 +218,31 @@ func TestRelationshipLinkages_EmbeddedSchemaShapesAreSupported(t *testing.T) {
 		"the OpenAPI spec contains relationship shapes that DashR does not support; update DashR or make the relationship definition unambiguous:\n%s",
 		strings.Join(unsupported, "\n"),
 	)
+}
+
+func composedPropertySchemas(root *openapi3.Schema, property string) []*openapi3.Schema {
+	var matches []*openapi3.Schema
+	seen := make(map[*openapi3.Schema]bool)
+	var walk func(*openapi3.Schema)
+	walk = func(schema *openapi3.Schema) {
+		if schema == nil || seen[schema] {
+			return
+		}
+		seen[schema] = true
+
+		if ref := schema.Properties[property]; ref != nil && ref.Value != nil {
+			matches = append(matches, ref.Value)
+		}
+		for _, refs := range []openapi3.SchemaRefs{schema.AllOf, schema.AnyOf, schema.OneOf} {
+			for _, ref := range refs {
+				if ref != nil {
+					walk(ref.Value)
+				}
+			}
+		}
+	}
+	walk(root)
+	return matches
 }
 
 func TestRelationshipLinkages_UsesHTTPMethod(t *testing.T) {

--- a/internal/commands/create/create.go
+++ b/internal/commands/create/create.go
@@ -43,11 +43,13 @@ func NewCmdCreate(inv *cmd.Invocation) *cmd.Command {
 		LongHelp: heredoc.New(inv.IO, heredoc.WithPreserveNewlines()).Mustf(`
 		The {{ template "mdCodeOrBold" "%s create" }} command creates a new resource via the API.
 
-		Provide attributes using {{ template "mdCodeOrBold" "-a key=value" }} (repeatable) or a raw request body with {{ template "mdCodeOrBold" "-i" }}.
+		Provide attributes using {{ template "mdCodeOrBold" "-a key=value" }} (repeatable), relationships using
+		{{ template "mdCodeOrBold" "-r name=id" }} (repeatable), or a raw request body with {{ template "mdCodeOrBold" "-i" }}.
 		Use {{ template "mdCodeOrBold" "-i -" }} to read the request body from stdin.
 
-		Note: {{ template "mdCodeOrBold" "-a" }} only sets data.attributes. Resources that require a relationships block
-		(e.g. variable sets, policy sets) must use {{ template "mdCodeOrBold" "-i" }} with a full JSON:API request body.
+		{{ template "mdCodeOrBold" "-r" }} sets data.relationships. The linkage type is inferred from the schema
+		(e.g. {{ template "mdCodeOrBold" "-r project=prj-..." }} links to type "projects"); override an unresolved
+		one with {{ template "mdCodeOrBold" "name:type=id" }}, and comma-separate ids for to-many relationships.
 		`, version.Name),
 		Args: cmd.PositionalArguments{
 			Autocomplete: complete.PredictSet(resource.CreatableNames()...),
@@ -75,6 +77,14 @@ func NewCmdCreate(inv *cmd.Invocation) *cmd.Command {
 					Value:        flagvalue.SimpleMap(nil, &opts.Attributes),
 				},
 				{
+					Name:         "relationship",
+					Shorthand:    "r",
+					DisplayValue: "NAME=ID",
+					Description:  "Relationship for the JSON:API request body as name=id (repeatable). The linkage type is inferred from the schema; override an unresolved one with name:type=id. Comma-separate ids for to-many relationships.",
+					Repeatable:   true,
+					Value:        flagvalue.SimpleMap(nil, &opts.Relationships),
+				},
+				{
 					Name:         "input",
 					Shorthand:    "i",
 					DisplayValue: "BODY",
@@ -91,6 +101,10 @@ func NewCmdCreate(inv *cmd.Invocation) *cmd.Command {
 			{
 				Preamble: "Create a workspace from a JSON file",
 				Command:  heredoc.New(inv.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s create workspace -i @workspace.json`, version.Name),
+			},
+			{
+				Preamble: "Create a workspace in a project (relationship type inferred from the schema)",
+				Command:  heredoc.New(inv.IO, heredoc.WithNoWrap(), heredoc.WithPreserveNewlines()).Mustf(`$ %s create workspace -a name=my-workspace -r project=prj-12dff4673ab9`, version.Name),
 			},
 			{
 				Preamble: "Create a project with inline JSON",
@@ -130,12 +144,12 @@ func runCreate(ctx context.Context, opts *Opts) error {
 		return fmt.Errorf("create is not supported for %s", res.Type)
 	}
 
-	if len(opts.Attributes) == 0 && opts.InputRequest == "" {
-		return fmt.Errorf("provide attributes with -a key=value or a request body with -i")
+	if len(opts.Attributes) == 0 && len(opts.Relationships) == 0 && opts.InputRequest == "" {
+		return fmt.Errorf("provide attributes with -a key=value, relationships with -r name=id, or a request body with -i")
 	}
 
-	if len(opts.Attributes) > 0 && opts.InputRequest != "" {
-		return fmt.Errorf("cannot use both -a (attributes) and -i (input body); choose one")
+	if opts.InputRequest != "" && (len(opts.Attributes) > 0 || len(opts.Relationships) > 0) {
+		return fmt.Errorf("cannot use -i (input body) together with -a (attributes) or -r (relationships); choose one")
 	}
 
 	org := cmdutil.ResolveOrganization(opts.ProfileOrganization, opts.Organization)
@@ -156,11 +170,13 @@ func runCreate(ctx context.Context, opts *Opts) error {
 	apiOpts.DryRun = opts.DryRun
 	apiOpts.InputRequest = opts.InputRequest
 	apiOpts.Attributes = opts.Attributes
+	apiOpts.Relationships = opts.Relationships
 
-	// ResourceType is only needed for the attribute path (api builds the JSON:API
-	// envelope from it). On the -i branch the user supplies the full body, so the
-	// type is unused — but setting it is harmless and keeps diagnostic logging accurate.
-	if len(opts.Attributes) > 0 {
+	// ResourceType names data.type when api builds the JSON:API envelope from
+	// attributes and/or relationships. On the -i branch the user supplies the full
+	// body, so the type is unused — but setting it is harmless and keeps diagnostic
+	// logging accurate.
+	if len(opts.Attributes) > 0 || len(opts.Relationships) > 0 {
 		apiOpts.ResourceType = res.Type
 	}
 

--- a/internal/commands/create/create.go
+++ b/internal/commands/create/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/flagvalue"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/heredoc"
+	"github.com/hashicorp/tfctl-cli/internal/pkg/openapi"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/resource"
 	"github.com/hashicorp/tfctl-cli/version"
 )
@@ -117,6 +118,10 @@ func NewCmdCreate(inv *cmd.Invocation) *cmd.Command {
 			opts.ProfileOrganization = inv.Profile.DefaultOrganization
 			opts.Args = args
 
+			// Reuse the process-cached schema for -r linkage inference instead of
+			// having RunAPI re-parse the embedded spec on every invocation.
+			opts.Schema = openapi.SchemaFactory(inv)
+
 			client, err := inv.NewAPIClient()
 			if err != nil {
 				return fmt.Errorf("failed to create API client: %w", err)
@@ -171,6 +176,7 @@ func runCreate(ctx context.Context, opts *Opts) error {
 	apiOpts.InputRequest = opts.InputRequest
 	apiOpts.Attributes = opts.Attributes
 	apiOpts.Relationships = opts.Relationships
+	apiOpts.Schema = opts.Schema
 
 	// ResourceType names data.type when api builds the JSON:API envelope from
 	// attributes and/or relationships. On the -i branch the user supplies the full

--- a/internal/commands/create/create.go
+++ b/internal/commands/create/create.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/tfctl-cli/internal/pkg/cmd"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/flagvalue"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/heredoc"
-	"github.com/hashicorp/tfctl-cli/internal/pkg/openapi"
 	"github.com/hashicorp/tfctl-cli/internal/pkg/resource"
 	"github.com/hashicorp/tfctl-cli/version"
 )
@@ -117,10 +116,6 @@ func NewCmdCreate(inv *cmd.Invocation) *cmd.Command {
 			opts.Quiet = inv.IsQuiet()
 			opts.ProfileOrganization = inv.Profile.DefaultOrganization
 			opts.Args = args
-
-			// Reuse the process-cached schema for -r linkage inference instead of
-			// having RunAPI re-parse the embedded spec on every invocation.
-			opts.Schema = openapi.SchemaFactory(inv)
 
 			client, err := inv.NewAPIClient()
 			if err != nil {

--- a/internal/commands/create/create_test.go
+++ b/internal/commands/create/create_test.go
@@ -129,7 +129,7 @@ func TestRunCreate(t *testing.T) {
 
 		err := runCreate(inv.ShutdownCtx, opts)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "provide attributes with -a key=value or a request body with -i")
+		assert.Contains(t, err.Error(), "provide attributes with -a key=value, relationships with -r name=id, or a request body with -i")
 	})
 
 	t.Run("create unsupported resource type", func(t *testing.T) {
@@ -204,7 +204,7 @@ func TestRunCreate(t *testing.T) {
 
 		err := runCreate(inv.ShutdownCtx, opts)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot use both -a (attributes) and -i (input body)")
+		assert.Contains(t, err.Error(), "cannot use -i (input body) together with -a (attributes) or -r (relationships)")
 	})
 
 	t.Run("explicit org flag overrides profile", func(t *testing.T) {


### PR DESCRIPTION
## Description

`-a key=value` builds a JSON:API request body without hand-writing JSON, but it only ever populates `data.attributes`, the `create` help tells users that anything needing a `relationships` block must fall back to `-i` with a full body. This adds the missing piece.

`-r name=id` populates `data.relationships` on both `tfctl api` and `tfctl create`:

```
tfctl create workspace -a name=foo -r project=prj-12dff4673ab9
{ "data": {
  "type": "workspaces",
  "attributes": { "name": "foo" },
  "relationships": {
    "project": { "data": { "type": "projects", "id": "prj-12dff4673ab9" } }
  }
}}
```

- The flag key is the relationship name, and the linkage type is inferred from the OpenAPI schema. 
- To find the type, the resolver follows the request body's `allOf/oneOf/items` down to the identifier's `type` enum. The same part tells us whether a relationship is to-one or to-many, so to-many ones take comma-separated ids and to-one ones reject a second id.
- Ambiguous / unknown relationships require an explicit -r name:type=id override. Ambiguous ones are those the schema pins to more than one type (e.g. `locked-by`can be users, teams, or runs.)
- Unknown relationship names produce a helpful error listing the valid names for that endpoint. 
- `create: -i` is now mutually exclusive with both `-a` and `-r`.


### Example Output

Type inferred from the schema, the key is project but the linkage type is projects:

```
$ tfctl create workspace -a name=my-workspace -r project=prj-12dff4673ab9 --dry-run
{
  "data": {
    "type": "workspaces",
    "attributes": { "name": "my-workspace" },
    "relationships": {
      "project": {
        "data": { "type": "projects", "id": "prj-12dff4673ab9" }
      }
    }
  }
}
```

Using the type as the key errors and points you at the right name:

```
$ tfctl api /organizations/my-org/workspaces -r projects=prj-1 --dry-run
ERROR: unknown relationship "projects" for this endpoint; valid relationships:
agent-pool, current-assessment-result, current-configuration-version, current-run,
current-state-version, latest-run, organization, outputs, project, readme, ssh-key, vars
(or override with -r projects:<type>=<id>)
```

For relationships the schema can't pin to one type, pass it explicitly with `name:type=id`:

```
$ tfctl api /organizations/my-org/workspaces -r locked-by:users=user-abc --dry-run
{
  "data": {
    "type": "workspaces",
    "relationships": {
      "locked-by": {
        "data": { "type": "users", "id": "user-abc" }
      }
    }
  }
}
```

<!--
One easy way to create a screenshot is:
go run github.com/homeport/termshot/cmd/termshot@v0.6.1 -c -f ~/screenshot.png -- tfctl mycommand --myflag
-->

### PR Checklist

- [ ] Run `npx changie new` or install [changie](https://changie.dev/guide/installation/) to prepare a new changelog entry for the next set of release notes.
- [ ] Ensure any command changes are sensitive to these global flags:
  - `--json` &mdash; Force machine readable output to stdout. Does not apply to stderr.
  - `--markdown` &mdash; Force markdown output to stdout. Does not apply to stderr.
  - `--dry-run` &mdash; Don't make any actual writes or other mutations. Describe what would have changed to stderr.
  - `--quiet` &mdash; Only render essential content.
- [ ] Get the logging interface from the context and add debug logging for interesting conditions and nonfatal situations.
- [ ] Run `make gen/screenshot` if the root command output changes.
- [ ] Add the `Autocomplete` field to **positional arguments** and **flags** to assist shell autocomplete.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
